### PR TITLE
Product Catalogs Pipeline Config (PHNX-1028)

### DIFF
--- a/configs/productcatalogs/productcatalogs-config.yml
+++ b/configs/productcatalogs/productcatalogs-config.yml
@@ -1,0 +1,33 @@
+schema: "1"
+pipeline:
+  application: productcatalogs
+  name: ProductCatalogs Production
+  id: phnx-productcatalogs-prod
+  template:
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/production-template.yml
+  variables:
+    application: productcatalogs
+    loadbalancer: productcatalogs-prod-api
+    clustername: productcatalogs-prod-api
+    stagingloadbalancer: productcatalogs-staging-api
+    stagingclustername: productcatalogs-staging-api
+    imagenamepattern: .*productcatalogs.*
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.ProductCatalogs/job/Phoenix.Service.ProductCatalogs.Tests.Smoke
+    gcrrepo: phoenix-177420/phoenix-service-productcatalogs
+    gcrimage: us.gcr.io/phoenix-177420/phoenix-service-productcatalogs
+  metadata:
+    description: The Product Catalogs Production Pipeline Config
+    name: ProductCatalogs-Production
+    owner: gbaker@centeredgesoftware.com
+    scopes:
+    - productcatalogs
+configuration:
+  inherit: ['concurrentExecutions', 'parameters', 'notifications']
+  triggers:
+  - account: gcr-phoenix
+    enabled: true
+    organization: phoenix-177420
+    registry: us.gcr.io
+    repository: phoenix-177420/phoenix-service-productcatalogs
+    runAsUser: phoenix-svc-account
+    type: docker

--- a/configs/productcatalogs/tempsmoketest-config.yml
+++ b/configs/productcatalogs/tempsmoketest-config.yml
@@ -1,0 +1,22 @@
+schema: "1"
+pipeline:
+  application: productcatalogs
+  name: Temp Smoke Test
+  id: phoenix-productcatalogs-tempsmoketest
+  template:
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/tempsmoketest-template.yml
+  variables:
+    application: productcatalogs
+    loadbalancer: productcatalogs-staging-api
+    clustername: productcatalogs-staging-temp
+    gcrrepo: phoenix-177420/phoenix-service-productcatalogs
+    gcrimage: us.gcr.io/phoenix-177420/phoenix-service-productcatalogs:latest
+  metadata:
+    description: A Temporary Smoke Test Configuration
+    name: ProductCatalogs-TempSmokeTest
+    owner: gbaker@centeredgesoftware.com
+    scopes:
+    - productcatalogs
+configuration:
+  inherit: ['concurrentExecutions', 'parameters', 'notifications']
+  triggers: []


### PR DESCRIPTION
Motivation
---
We want to convert all the spinnaker pipelines to using templates.

Modification
---
- Added Product Catalogs pipeline config
- Added Product Catalogs temp smoke test config

https://centeredge.atlassian.net/browse/PHNX-1028