### PR TITLE
Remove API_GATEWAY_KEY (PHNX-1081)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -326,12 +326,7 @@ stages:
         volumeMounts: []
       - args: []
         command: []
-        envVars:
-        - envSource:
-            secretSource:
-              key: key
-              secretName: api-gateway
-          name: API_GATEWAY_KEY
+        envVars: []
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:2


### PR DESCRIPTION
Motivation
---
The presence of the API_GATEWAY_KEY in the Production cluster definition prevented the microservices from communicating with each other.

Modifications
---
- Removed API_GATEWAY_KEY from the Production cluster definition

https://centeredge.atlassian.net/browse/PHNX-1081