### PR TITLE
BE Config Wrong Smoke Test Name (PHNX-1089)

### DIFF
--- a/configs/businessentities/businessentities-config.yml
+++ b/configs/businessentities/businessentities-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: businessentities-dev
     stagingclustername: businessentities-staging-api
     imagenamepattern: .*businessentities.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.BusinessEntities/job/Phoenix.Service.BusinessEntities.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.BusinessEntities/job/Phoenix.Service.BusinessEntities.Smoke
     gcrrepo: phoenix-177420/phoenix-service-businessentities
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-businessentities
   metadata:


### PR DESCRIPTION
Motivation
---
The BE Config had the wrong name for the Smoke Test project which caused them to not run when the pipeline executed.

Modification
---
- Renamed the Smoke Test project to Phoenix.Service.BusinessEntities.Smoke

https://centeredge.atlassian.net/browse/PHNX-1089