### PR TITLE
Update Transactions Smoke Test Name (PHNX-1093)

### DIFF
--- a/configs/transactions/transactions-config.yml
+++ b/configs/transactions/transactions-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: transactions-staging-api
     stagingclustername: transactions-staging-api
     imagenamepattern: .*transactions.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Transactions/job/Phoenix.Service.Transactions.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Transactions/job/Phoenix.Service.Transactions.Smoke
     gcrrepo: phoenix-177420/phoenix-service-transactions
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-transactions
   metadata:


### PR DESCRIPTION
Motivation
---
There's been inconsistency in the naming of our Smoke Test projects.

Sometimes it's:
Phoenix.Service.

{Servicename}

.Smoke

other times it's:
Phoenix.Service.

{ServiceName}

.Tests.Smoke

The old pipeline was updated 7.3.2018 @ 2:50p to use the correct format for Transactions.
The pipeline template config for Transactions should be updated too.

Modification
---
- Changed the Transactions smoketestjob parameter to point to the correctly named project

https://centeredge.atlassian.net/browse/PHNX-1093