### PR TITLE
Update Smoke Test Names (PHNX-1093)

### DIFF
--- a/configs/posdesigner/posdesigner-config.yml
+++ b/configs/posdesigner/posdesigner-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: posdesigner-staging-api
     stagingclustername: posdesigner-staging-api
     imagenamepattern: .*posdesigner.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.POSDesigner/job/Phoenix.Service.POSDesigner.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.POSDesigner/job/Phoenix.Service.POSDesigner.Smoke
     gcrrepo: phoenix-177420/phoenix-service-posdesigner
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-posdesigner
   metadata:

--- a/configs/pricelists/pricelists-config.yml
+++ b/configs/pricelists/pricelists-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: pricelists-staging-api
     stagingclustername: pricelists-staging-api
     imagenamepattern: .*pricelists.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.PriceLists/job/Phoenix.Service.PriceLists.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.PriceLists/job/Phoenix.Service.PriceLists.Smoke
     gcrrepo: phoenix-177420/phoenix-service-pricelists
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-pricelists
   metadata:

--- a/configs/productcatalogs/productcatalogs-config.yml
+++ b/configs/productcatalogs/productcatalogs-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: productcatalogs-staging-api
     stagingclustername: productcatalogs-staging-api
     imagenamepattern: .*productcatalogs.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.ProductCatalogs/job/Phoenix.Service.ProductCatalogs.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.ProductCatalogs/job/Phoenix.Service.ProductCatalogs.Smoke
     gcrrepo: phoenix-177420/phoenix-service-productcatalogs
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-productcatalogs
   metadata:

--- a/configs/transactions/transactions-config.yml
+++ b/configs/transactions/transactions-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: transactions-staging-api
     stagingclustername: transactions-staging-api
     imagenamepattern: .*transactions.*
-    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Transactions/job/Phoenix.Service.Transactions.Tests.Smoke
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Transactions/job/Phoenix.Service.Transactions.Smoke
     gcrrepo: phoenix-177420/phoenix-service-transactions
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-transactions
   metadata:


### PR DESCRIPTION
Motivation
---
There's been inconsistency in the naming of our Smoke Test projects.

Sometimes it's:
Phoenix.Service.{Servicename}.Smoke

other times it's:
Phoenix.Service.{ServiceName}.Tests.Smoke

Pipeline Smoke Test project names were recently updated to made consistent.
The pipeline template configs for all the microservice pipelines should be updated to
Phoenix.Service.[ServiceName].Smoke

Modification
---
- Changed the smoketestjob parameter for all pipeline configs to point to the correctly named project

https://centeredge.atlassian.net/browse/PHNX-1093