### PR TITLE
Update Nginx Proxy to Version 4 (PHNX-1129)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -151,7 +151,7 @@ stages:
           name: API_GATEWAY_KEY
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:2
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:4
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
           tag: "2"
@@ -329,7 +329,7 @@ stages:
         envVars: []
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:2
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:4
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
           tag: "2"


### PR DESCRIPTION
Motivation
---
A change was made to our ngninx-proxy image to fix a bug. In order to incorporate that into our microservices, we need to update the production template to reference the new version.

Modification
---
- Updated the ngnix-proxy images to use version 4

https://centeredge.atlassian.net/browse/PHNX-1129