### PR TITLE
Update Template Tag to 4 (PHNX-1130)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -154,7 +154,7 @@ stages:
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:4
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "2"
+          tag: "4"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -332,7 +332,7 @@ stages:
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:4
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "2"
+          tag: "4"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy


### PR DESCRIPTION
Motivation
---
Apparently the "tag" field in the imageDescription block of the template controls which version of an image is pulled down from gcr regardless of which version is specified in the imageId field.

Modification
---
- Updated the nginx proxy imageDescription "tag" field to the value "4"

https://centeredge.atlassian.net/browse/PHNX-1130