### PR TITLE
Update nginx-proxy to version 4 (PHNX-1271)

### DIFF
--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -144,10 +144,10 @@ stages:
           name: API_GATEWAY_KEY
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:2
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:4
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "2"
+          tag: "4"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
---
The Temp Smoke Test template was still using the old nginx-proxy:2

Modification
---
- Updated to nginx-proxy:4

https://centeredge.atlassian.net/browse/PHNX-1271
