### PR TITLE
Add activity scheduling service (PHNX-1279)

### DIFF
--- a/configs/activityscheduling/activityscheduling-config.yml
+++ b/configs/activityscheduling/activityscheduling-config.yml
@@ -1,0 +1,33 @@
+schema: "1"
+pipeline:
+  application: actsched
+  name: ActivityScheduling Production
+  id: phnx-actsched-prod
+  template:
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/production-template.yml
+  variables:
+    application: actsched
+    loadbalancer: actsched-prod-api
+    clustername: actsched-prod-api
+    stagingloadbalancer: actsched-staging-api
+    stagingclustername: actsched-staging-api
+    imagenamepattern: .*activityscheduling.*
+    smoketestjob: Phoenix/job/Services/job/Phoenix.Service.ActivityScheduling/job/Phoenix.Service.ActivityScheduling.Smoke
+    gcrrepo: phoenix-177420/phoenix-service-activityscheduling
+    gcrimage: us.gcr.io/phoenix-177420/phoenix-service-activityscheduling
+  metadata:
+    description: The ActivityScheduling Production Pipeline Config
+    name: ActivityScheduling-Production
+    owner: gbaker@centeredgesoftware.com
+    scopes:
+    - actsched
+configuration:
+  inherit: ['concurrentExecutions', 'parameters', 'notifications']
+  triggers:
+  - account: gcr-phoenix
+    enabled: true
+    organization: phoenix-177420
+    registry: us.gcr.io
+    repository: phoenix-177420/phoenix-service-activityscheduling
+    runAsUser: phoenix-svc-account
+    type: docker

--- a/configs/activityscheduling/tempsmoketest-config.yml
+++ b/configs/activityscheduling/tempsmoketest-config.yml
@@ -1,0 +1,22 @@
+schema: "1"
+pipeline:
+  application: actsched
+  name: Temp Smoke Test
+  id: phoenix-activityscheduling-tempsmoketest
+  template:
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/tempsmoketest-template.yml
+  variables:
+    application: actsched
+    loadbalancer: actsched-staging-api
+    clustername: actsched-staging-temp
+    gcrrepo: phoenix-177420/phoenix-service-activityscheduling
+    gcrimage: us.gcr.io/phoenix-177420/phoenix-service-activityscheduling:latest
+  metadata:
+    description: A Temporary Smoke Test Configuration
+    name: ActivityScheduling-TempSmokeTest
+    owner: gbaker@centeredgesoftware.com
+    scopes:
+    - actsched
+configuration:
+  inherit: ['concurrentExecutions', 'parameters', 'notifications']
+  triggers: []


### PR DESCRIPTION
Motivation
--------------
In the domain we determined that "Activity" was a better name that "Event"

Modifications
------------------
Add configs for activities service

https://centeredge.atlassian.net/browse/PHNX-1279
