### PR TITLE
Add AWS Role variable to pod annotations (PHNX-1465)

### DIFF
--- a/configs/authn/authentication-config.yml
+++ b/configs/authn/authentication-config.yml
@@ -15,6 +15,7 @@ pipeline:
     smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Authentication/job/Phoenix.Service.Authentication.Smoke
     gcrrepo: phoenix-177420/phoenix-service-authentication
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-authentication
+    awsrole: PhoenixAuthenticationService
   metadata:
     description: The Authentication Production Pipeline Config
     name: Authentication-Production

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -38,6 +38,8 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
+- name: awsrole
+  description: The AWS role to assign to pods
 stages:
 - config:
     clusters:
@@ -196,7 +198,8 @@ stages:
       - "{{ stagingloadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations: {}
+      podAnnotations:
+        iam.amazonaws.com/role: "{{ awsrole }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}
@@ -389,7 +392,8 @@ stages:
       - "{{ loadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations: {}
+      podAnnotations:
+        iam.amazonaws.com/role: "{{ awsrole }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}


### PR DESCRIPTION
Motivation
---
We need to be able to specify the AWS role used for a pod

Modifications
---
Added a new "awsrole" variable to the template.  Implemented its usage for AuthN

https://centeredge.atlassian.net/browse/PHNX-1465
