### PR TITLE
Change to using podAnnoationsVar (PHNX-1471)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -38,8 +38,10 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
-- name: awsrole
-  description: The AWS role to assign to pods
+- name: podAnnotations
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to pods
 stages:
 - config:
     clusters:
@@ -198,8 +200,7 @@ stages:
       - "{{ stagingloadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations:
-        iam.amazonaws.com/role: "{{ awsrole }}"
+      podAnnotations: "{{ podAnnotations }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}
@@ -392,8 +393,7 @@ stages:
       - "{{ loadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations:
-        iam.amazonaws.com/role: "{{ awsrole }}"
+      podAnnotations: "{{ podAnnotations }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}


### PR DESCRIPTION
Motivation
---
Spinnaker pipelines are failing.

Modifications
---
Switched from using an awsrole var to using a podAnnotations var that defaults to an empty object

https://centeredge.atlassian.net/browse/PHNX-1471
