### PR TITLE
Configure podAnnotations for AuthN (PHNX-1471)

### DIFF
--- a/configs/authn/authentication-config.yml
+++ b/configs/authn/authentication-config.yml
@@ -15,7 +15,7 @@ pipeline:
     smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Authentication/job/Phoenix.Service.Authentication.Smoke
     gcrrepo: phoenix-177420/phoenix-service-authentication
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-authentication
-    awsrole: PhoenixAuthenticationService
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixAuthenticationService }"
   metadata:
     description: The Authentication Production Pipeline Config
     name: Authentication-Production

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -38,8 +38,10 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
-- name: awsrole
-  description: The AWS role to assign to pods
+- name: podAnnotations
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to pods
 stages:
 - config:
     clusters:
@@ -198,8 +200,7 @@ stages:
       - "{{ stagingloadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations:
-        iam.amazonaws.com/role: "{{ awsrole }}"
+      podAnnotations: "{{ podAnnotations }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}
@@ -392,8 +393,7 @@ stages:
       - "{{ loadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations:
-        iam.amazonaws.com/role: "{{ awsrole }}"
+      podAnnotations: "{{ podAnnotations }}"
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -16,6 +16,10 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
+- name: podAnnotations
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to pods
 stages:
 - config:
     clusters:


### PR DESCRIPTION
Motivation
---
We need to add an aws role pod annotation to the AuthN service

Modifications
---
Added the podAnnotations variable to the smoketest template. Added the role pod annotations to the AuthN config

https://centeredge.atlassian.net/browse/PHNX-1471
