### PR TITLE
Configure podAnnotations for AuthN smoke (PHNX-1471)

### DIFF
--- a/configs/authn/tempsmoketest-config.yml
+++ b/configs/authn/tempsmoketest-config.yml
@@ -11,6 +11,7 @@ pipeline:
     clustername: authn-staging-temp
     gcrrepo: phoenix-177420/phoenix-service-authentication
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-authentication:latest
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixAuthenticationService }"
   metadata:
     description: A Temporary Smoke Test Configuration
     name: Authentication-TempSmokeTest


### PR DESCRIPTION
Motivation
---
We need to add an aws role pod annotation to the AuthN smoke test pipeline

Modifications
---
Added the podAnnotations variable to the smoketest pipeline

https://centeredge.atlassian.net/browse/PHNX-1471
