### PR TITLE
Add Cognito default temp pass env var to smokes (PHNX-1540)

### DIFF
--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -94,6 +94,11 @@ stages:
               key: region
               secretName: cognito-creds
           name: COGNITO__Region
+        - envSource:
+            secretSource:
+              key: defaultTempPass
+              secretName: cognito-creds
+          name: COGNITO__DefaultTemporaryPassword
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true


### PR DESCRIPTION
Motivation
---
We want to have a default temporary password for smoke tests so we can test user creation and password reset

Modifications
---
Add the secret->env var mapping

https://centeredge.atlassian.net/browse/PHNX-1540
