### PR TITLE
Added COGNITO_ClientId to Production Cluster (PHNX-1551)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -308,6 +308,11 @@ stages:
           name: COGNITO__ClientId
         - envSource:
             secretSource:
+              key: clientSecret
+              secretName: cognito-creds
+          name: COGNITO__ClientSecret
+        - envSource:
+            secretSource:
               key: poolId
               secretName: cognito-creds
           name: COGNITO__UserPoolId


### PR DESCRIPTION
Motivation
---
COGNITO_ClientId was missing from the declaration for the production cluster causing authentication to fail in production.

Modification
---
- Added COGNITO_ClientId to the production cluster declaration

https://centeredge.atlassian.net/browse/PHNX-1551
