### PR TITLE
Pipeline Event Notifications (PHNX-1556)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -505,11 +505,10 @@ stages:
       alertType: success
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }}
-        Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
+      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
       title: "Deployed {{ application }} to {{ clustername }}"
     stageEnabled:
-      expression: '#stage("Deploy Production").status.toString() == ''SUCCEEDED'''
+      expression: "#stage('Deploy Production').status.toString() == 'SUCCEEDED'"
       type: expression
     statusUrlResolution: getMethod
   dependsOn:
@@ -526,11 +525,10 @@ stages:
       alertType: error
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }}
-        Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
+      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
       title: "Failed to deploy {{ application }} to {{ clustername }}"
     stageEnabled:
-      expression: '#stage("Deploy Production").status.toString() != ''SUCCEEDED'''
+      expression: "#stage('Deploy Production').status.toString() != 'SUCCEEDED'"
       type: expression
     statusUrlResolution: getMethod
   dependsOn:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -42,6 +42,9 @@ variables:
   type: object
   defaultValue: {}
   description: The annotations to assign to pods
+- name: product
+  description: The name of the product this deployment belongs to
+  defaultValue: Phoenix
 stages:
 - config:
     clusters:
@@ -480,3 +483,64 @@ stages:
   inject: {}
   name: Destroy Staging Server Group
   type: destroyServerGroup
+- config:
+    alias: preconfiguredWebhook
+    parameterValues:
+      alertType: info
+      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      product: "{{ product }}"
+      text: Start Deploy of ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+      title: Start Deploy of ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+    statusUrlResolution: getMethod
+  dependsOn:
+  - phoenix-scriptedpipelinetest-smoketest
+  id: pipelineevent-start-deployment
+  inheritanceControl: {}
+  inject: {}
+  name: Publish Start Event
+  type: pipelineEvent
+- config:
+    alias: preconfiguredWebhook
+    parameterValues:
+      alertType: success
+      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      product: "{{ product }}"
+      text: "'Deployed image {{ gcrimage }}
+        of ${execution[''application'']} to ${#stage(''Deploy Production'').context.clusters[0].stack}
+        Deploy Duration: ${new java.text.SimpleDateFormat(''HH:mm:ss'').format(#stage(''Deploy Production'').endTime
+        - execution[''startTime''])}'"
+      title: Deployed ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+    stageEnabled:
+      expression: '#stage("Deploy Production").status.toString() == ''SUCCEEDED'''
+      type: expression
+    statusUrlResolution: getMethod
+  dependsOn:
+  - phoenix-production-deploy
+  id: pipelineevent-success
+  inheritanceControl: {}
+  inject: {}
+  name: Publish Success Event
+  type: pipelineEvent
+- config:
+    alias: preconfiguredWebhook
+    failOnFailedExpressions: true
+    parameterValues:
+      alertType: error
+      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      product: "{{ product }}"
+      text: "'Failed to deploy image {{ gcrimage }}
+        of ${execution[''application'']} to ${#stage(''Deploy Production'').context.clusters[0].stack}
+        Deploy Duration: ${new java.text.SimpleDateFormat(''HH:mm:ss'').format(#stage(''Deploy Production'').endTime
+        - execution[''startTime''])}'"
+      title: Failed to deploy ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+    stageEnabled:
+      expression: '#stage("Deploy Production").status.toString() != ''SUCCEEDED'''
+      type: expression
+    statusUrlResolution: getMethod
+  dependsOn:
+  - phoenix-production-deploy
+  id: pipelineevent-failed
+  inheritanceControl: {}
+  inject: {}
+  name: Publish Failed Event
+  type: pipelineEvent

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -505,7 +505,7 @@ stages:
       alertType: success
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
+      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration - ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
       title: "Deployed {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: "#stage('Deploy Production').status.toString() == 'SUCCEEDED'"
@@ -525,7 +525,7 @@ stages:
       alertType: error
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
+      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration - ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
       title: "Failed to deploy {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: "#stage('Deploy Production').status.toString() != 'SUCCEEDED'"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -505,7 +505,7 @@ stages:
       alertType: success
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration - ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
+      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage('Deploy Production').endTime - execution['startTime'])}"
       title: "Deployed {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: "#stage('Deploy Production').status.toString() == 'SUCCEEDED'"
@@ -525,7 +525,7 @@ stages:
       alertType: error
       environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration - ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
+      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }} Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage('Deploy Production').endTime - execution['startTime'])}"
       title: "Failed to deploy {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: "#stage('Deploy Production').status.toString() != 'SUCCEEDED'"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -487,10 +487,10 @@ stages:
     alias: preconfiguredWebhook
     parameterValues:
       alertType: info
-      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: Start Deploy of ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
-      title: Start Deploy of ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+      text: "Start Deploy of {{ application }} to {{ clustername }}"
+      title: "Start Deploy of {{ application }} to {{ clustername }}"
     statusUrlResolution: getMethod
   dependsOn:
   - phoenix-scriptedpipelinetest-smoketest
@@ -503,13 +503,11 @@ stages:
     alias: preconfiguredWebhook
     parameterValues:
       alertType: success
-      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "'Deployed image {{ gcrimage }}
-        of ${execution[''application'']} to ${#stage(''Deploy Production'').context.clusters[0].stack}
-        Deploy Duration: ${new java.text.SimpleDateFormat(''HH:mm:ss'').format(#stage(''Deploy Production'').endTime
-        - execution[''startTime''])}'"
-      title: Deployed ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+      text: "Deployed image {{ gcrimage }} of {{ application }} to {{ clustername }}
+        Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss').format(#stage(Deploy Production').endTime - execution['startTime'])}"
+      title: "Deployed {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: '#stage("Deploy Production").status.toString() == ''SUCCEEDED'''
       type: expression
@@ -526,13 +524,11 @@ stages:
     failOnFailedExpressions: true
     parameterValues:
       alertType: error
-      environment: ${#stage('Deploy Production').context.clusters[0].stack}
+      environment: "{{ clustername }}"
       product: "{{ product }}"
-      text: "'Failed to deploy image {{ gcrimage }}
-        of ${execution[''application'']} to ${#stage(''Deploy Production'').context.clusters[0].stack}
-        Deploy Duration: ${new java.text.SimpleDateFormat(''HH:mm:ss'').format(#stage(''Deploy Production'').endTime
-        - execution[''startTime''])}'"
-      title: Failed to deploy ${execution['application']} to ${#stage('Deploy Production').context.clusters[0].stack}
+      text: "Failed to deploy image {{ gcrimage }} of {{ application }} to {{ clustername }}
+        Deploy Duration: ${new java.text.SimpleDateFormat('HH:mm:ss).format(#stage('Deploy Production).endTime - execution['startTime'])}"
+      title: "Failed to deploy {{ application }} to {{ clustername }}"
     stageEnabled:
       expression: '#stage("Deploy Production").status.toString() != ''SUCCEEDED'''
       type: expression


### PR DESCRIPTION
Motivation
---
We'd like to start capturing deployment metrics. In order to do that, we've introduced a webhook into Spinnaker that feeds Datadog. The pipelines need to be updated with stages that feed data into the webhook so Datadog can start capturing metrics.

Modification
---
- Added three new stages to the template
- One stage when deployment starts
- One stage when deployment succeeds
- One stage when deployment fails

https://centeredge.atlassian.net/browse/PHNX-1556
