### PR TITLE
BUGFIX: Change stage type to datadogEvent (PHNX-1561)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -498,7 +498,7 @@ stages:
   inheritanceControl: {}
   inject: {}
   name: Publish Start Event
-  type: pipelineEvent
+  type: datadogEvent
 - config:
     alias: preconfiguredWebhook
     parameterValues:
@@ -517,7 +517,7 @@ stages:
   inheritanceControl: {}
   inject: {}
   name: Publish Success Event
-  type: pipelineEvent
+  type: datadogEvent
 - config:
     alias: preconfiguredWebhook
     failOnFailedExpressions: true
@@ -537,4 +537,4 @@ stages:
   inheritanceControl: {}
   inject: {}
   name: Publish Failed Event
-  type: pipelineEvent
+  type: datadogEvent


### PR DESCRIPTION
Motivation
---
When attempting to add new event logging to our pipelines, we adjusted the type name from datadogEvent to a more generic name of pipelineEvent.

Apparently that breaks things.

Modification
---
- Changed type from pipelineEvent to datadogEvent

https://centeredge.atlassian.net/browse/PHNX-1561
