### PR TITLE
Memory and CPU Limits for Pods (PHNX-1542)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -47,16 +47,16 @@ variables:
   defaultValue: Phoenix
 - name: requestcpu
   description: The CPU limit for requests
-  defaultValue: 200m
+  defaultValue: 100m
 - name: requestmem
   description: The Memory limit for requests
-  defaultValue: 256mi
-- name: podcpu
-  description: The CPU limit for a given pod
-  defaultValue: 500m
-- name: podmem
-  description: The Memory limit for a pod
   defaultValue: 512mi
+- name: maxcpu
+  description: The CPU limit for a given pod
+  defaultValue: 200m
+- name: maxmem
+  description: The Memory limit for a pod
+  defaultValue: 1024mi
 stages:
 - config:
     clusters:
@@ -341,8 +341,8 @@ stages:
           repository: "{{ gcrrepo }}"
         imagePullPolicy: IFNOTPRESENT
         limits:
-          cpu: "{{ podcpu }}"
-          memory: "{{ podmem }}"
+          cpu: "{{ maxcpu }}"
+          memory: "{{ maxmem }}"
         livenessProbe:
           failureThreshold: 3
           handler:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -45,6 +45,18 @@ variables:
 - name: product
   description: The name of the product this deployment belongs to
   defaultValue: Phoenix
+- name: requestcpu
+  description: The CPU limit for requests
+  defaultValue: 200m
+- name: requestmem
+  description: The Memory limit for requests
+  defaultValue: 128Mi
+- name: podcpu
+  description: The CPU limit for a given pod
+  defaultValue: 500m
+- name: podmem
+  description: The Memory limit for a pod
+  defaultValue: 512mi
 stages:
 - config:
     clusters:
@@ -164,9 +176,6 @@ stages:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        requests:
-          cpu: ""
-          memory: ""
         volumeMounts: []
       - args: []
         command: []
@@ -331,7 +340,9 @@ stages:
           registry: us.gcr.io
           repository: "{{ gcrrepo }}"
         imagePullPolicy: IFNOTPRESENT
-        limits: {}
+        limits:
+          cpu: "{{ podcpu }}"
+          memory: "{{ podmem }}"
         livenessProbe:
           failureThreshold: 3
           handler:
@@ -369,7 +380,9 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        requests: {}
+        requests: 
+          cpu: "{{ requestcpu }}"
+          memory: "{{ requestmem }}"
         volumeMounts: []
       - args: []
         command: []

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -46,10 +46,10 @@ variables:
   description: The name of the product this deployment belongs to
   defaultValue: Phoenix
 - name: requestcpu
-  description: The CPU limit for requests
+  description: The amount of CPU requested
   defaultValue: 100m
 - name: requestmem
-  description: The Memory limit for requests
+  description: The amount of Memory requested
   defaultValue: 512mi
 - name: maxcpu
   description: The CPU limit for a given pod

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -50,7 +50,7 @@ variables:
   defaultValue: 200m
 - name: requestmem
   description: The Memory limit for requests
-  defaultValue: 128Mi
+  defaultValue: 256mi
 - name: podcpu
   description: The CPU limit for a given pod
   defaultValue: 500m


### PR DESCRIPTION
Motivation
---
With no upper limits specific, our pods were abusing AWS and allowed to run amok. We should get them under control.

I did not add limits to our Staging pods as those are short-lived.

Credit to @mmmasent for initial research and implementation.

Modification
---
- Added pod limits for CPU and Memory
- Added request limits for CPU and Memory
- Parameterized the limit values with default values which can be overriden in config files

https://centeredge.atlassian.net/browse/PHNX-1542
