### PR TITLE
Changed to StatsD version of nginx proxy (PHNX-1725)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -200,7 +200,7 @@ stages:
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
-          value: "{{ application }}"
+          value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-15
@@ -402,13 +402,23 @@ stages:
         volumeMounts: []
       - args: []
         command: []
-        envVars: []
+        envVars:
+        - name: STATSD_ENABLED
+          value: "{{ statsdEnabled }}"
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-15
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-15"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -57,6 +57,12 @@ variables:
 - name: maxmem
   description: The Memory limit for a pod
   defaultValue: 1024Mi
+- name: statsdEnabled
+  description: Whether or not statsd logging is enabled
+  defaultValue: true
+- name: statsdSampleRate
+  description: The percentage of requests to log to statsd
+  defaultValue: 100
 stages:
 - config:
     clusters:
@@ -180,17 +186,27 @@ stages:
       - args: []
         command: []
         envVars:
-        - envSource:
+        - name: API_GATEWAY_KEY
+          envSource:
             secretSource:
               key: key
               secretName: api-gateway
-          name: API_GATEWAY_KEY
+        - name: STATSD_ENABLED
+          value: "{{ statsdEnabled }}"
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-15
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-15"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -20,6 +20,12 @@ variables:
   type: object
   defaultValue: {}
   description: The annotations to assign to pods
+- name: statsdEnabled
+  description: Whether or not statsd logging is enabled
+  defaultValue: false
+- name: statsdSampleRate
+  description: The percentage of requests to log to statsd
+  defaultValue: 100
 stages:
 - config:
     clusters:
@@ -151,17 +157,27 @@ stages:
       - args: []
         command: []
         envVars:
-        - envSource:
+        - name: API_GATEWAY_KEY
+          envSource:
             secretSource:
               key: key
               secretName: api-gateway
-          name: API_GATEWAY_KEY
+        - name: STATSD_ENABLED
+          value: "{{ statsdEnabled }}"
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-15
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-15"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -22,7 +22,7 @@ variables:
   description: The annotations to assign to pods
 - name: statsdEnabled
   description: Whether or not statsd logging is enabled
-  defaultValue: false
+  defaultValue: true
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd
   defaultValue: 100
@@ -171,7 +171,7 @@ stages:
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
-          value: "{{ application }}"
+          value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-15


### PR DESCRIPTION
Motivation
---
We want to be able to do RED monitoring of all of our microservices

Modifications
---
Updated to a CI version of the nginx proxy that has statd baked in that does request logging into datadog.  Added necessary environment variables

https://centeredge.atlassian.net/browse/PHNX-1725
