### PR TITLE
Changed to StatsD version of nginx proxy (PHNX-1725)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -57,6 +57,10 @@ variables:
 - name: maxmem
   description: The Memory limit for a pod
   defaultValue: 1024Mi
+  defaultValue: true
+- name: statsdSampleRate
+  description: The percentage of requests to log to statsd. Set to 0 to disable
+  defaultValue: 100
 stages:
 - config:
     clusters:
@@ -180,17 +184,25 @@ stages:
       - args: []
         command: []
         envVars:
-        - envSource:
+        - name: API_GATEWAY_KEY
+          envSource:
             secretSource:
               key: key
               secretName: api-gateway
-          name: API_GATEWAY_KEY
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-17
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-17"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -386,13 +398,21 @@ stages:
         volumeMounts: []
       - args: []
         command: []
-        envVars: []
+        envVars:
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-17
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-17"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -20,6 +20,9 @@ variables:
   type: object
   defaultValue: {}
   description: The annotations to assign to pods
+- name: statsdSampleRate
+  description: The percentage of requests to log to statsd. Set to 0 to disable
+  defaultValue: 100
 stages:
 - config:
     clusters:
@@ -151,17 +154,25 @@ stages:
       - args: []
         command: []
         envVars:
-        - envSource:
+        - name: API_GATEWAY_KEY
+          envSource:
             secretSource:
               key: key
               secretName: api-gateway
-          name: API_GATEWAY_KEY
+        - name: STATSD_SERVER
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: STATSD_SAMPLE_RATE
+          value: "{{ statsdSampleRate }}"
+        - name: SERVICE_NAME
+          value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:7
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-4-17
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "7"
+          tag: "PR-4-17"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
---
We want to be able to do RED monitoring of all of our microservices

Modifications
---
Updated to a CI version of the nginx proxy that has statd baked in that does request logging into datadog.  Added necessary environment variables

https://centeredge.atlassian.net/browse/PHNX-1725
