### PR TITLE
Change the number of retained deployments (DO-357)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -489,7 +489,7 @@ stages:
     namespaces:
     - default
     retainLargerOverNewer: "false"
-    shrinkToSize: 3
+    shrinkToSize: 2
   dependsOn:
   - phoenix-production-disablecluster
   id: phoenix-production-shrinkcluster


### PR DESCRIPTION
Motivation
----------
Currently we are retaining 3 deployments which is more than
necessary at this point in time. Reducing it to 2 will still
allow us to rollback to the previous version if required.

Modifications
-------------
Change the definition in the Shrink Cluster stage

https://centeredge.atlassian.net/browse/DO-357
