### PR TITLE
 User Settable Build Number (PHNX-1808)

### DIFF
--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -25,8 +25,7 @@ variables:
   description: The annotations to assign to pods
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 100
-- name: 
+  defaultValue: 100 
 stages:
 - config:
     clusters:

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -16,6 +16,9 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
+- name: gcrimagetag
+  description: The tag of the image you want to run
+  defaultValue: latest
 - name: podAnnotations
   type: object
   defaultValue: {}
@@ -23,6 +26,7 @@ variables:
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
   defaultValue: 100
+- name: 
 stages:
 - config:
     clusters:
@@ -108,7 +112,7 @@ stages:
           imageId: "{{ gcrimage }}"
           registry: us.gcr.io
           repository: "{{ gcrrepo }}"
-          tag: latest
+          tag: "{{ gcrimagetag }}"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         livenessProbe:


### PR DESCRIPTION
Motivation
---
QA needs the ability to specifically set which image is being run in the Temp Smoke Test pipelines.

Modification
---
- Added a new parameter 'gcrimagetag'
- Parameter default value is latest
- Value is settable using the Spinnaker UI