### PR TITLE
Remove gcrimagetag variable (PHNX-1899)

### DIFF
--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -16,9 +16,6 @@ variables:
   description: The GCR image of the container to run
 - name: gcrrepo
   description: The GCR repository to connect to
-- name: gcrimagetag
-  description: The tag of the image you want to run
-  defaultValue: latest
 - name: podAnnotations
   type: object
   defaultValue: {}
@@ -111,7 +108,6 @@ stages:
           imageId: "{{ gcrimage }}"
           registry: us.gcr.io
           repository: "{{ gcrrepo }}"
-          tag: "{{ gcrimagetag }}"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         livenessProbe:


### PR DESCRIPTION
Motivation
---
Adding a variable for the image tag seems to have broken things for Spinnaker. We should remove it.

Modification
---
- Removed the offending variable gcrimagetag

https://centeredge.atlassian.net/browse/PHNX-1899
