### PR TITLE
Add LaunchDarkly Sdk key to templates (PHNX-2007)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -134,6 +134,11 @@ stages:
               key: region
               secretName: cognito-creds
           name: COGNITO__Region
+        - envSource:
+            secretSource:
+              key: key
+              secretName: feature-flag-key
+          name: LaunchDarklyOptions__SdkKey
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -344,6 +349,11 @@ stages:
               key: region
               secretName: cognito-creds
           name: COGNITO__Region
+        - envSource:
+            secretSource:
+              key: key
+              secretName: feature-flag-key
+          name: LaunchDarklyOptions__SdkKey
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -105,6 +105,11 @@ stages:
               key: defaultTempPass
               secretName: cognito-creds
           name: COGNITO__DefaultTemporaryPassword
+        - envSource:
+            secretSource:
+              key: key
+              secretName: feature-flag-key
+          name: LaunchDarklyOptions__SdkKey
         imageDescription:
           account: gcr-phoenix
           imageId: "{{ gcrimage }}"


### PR DESCRIPTION
Motivation
---
The auth in Mashtub depends on a feature flag from LaunchDarkly.  We need access to the LaunchDarkly Sdk key in order to check the flag.

Modifications
---
Added an environement variable that injects the sdk key into the service container