### PR TITLE
Update pipeline to run smoketests (PHNX-2155)

### DIFF
--- a/configs/mashtub2/mashtub2-config.yml
+++ b/configs/mashtub2/mashtub2-config.yml
@@ -12,8 +12,8 @@ pipeline:
     stagingloadbalancer: mashtub2-staging-api
     stagingclustername: mashtub2-staging-api
     imagenamepattern: .*mashtub2.*
-    smoketestjob: Phoenix/job/MashTub.Net/job/MashTub.SmokeTests
-    smoketestparams: "{ BASE_URL: https://api-ingress.phoenix.centeredge.io/v1-staging, SDK_VERSION: ${#stage( 'FindImage' )["context"]["amiDetails"][0]["tag"]} }"
+    smoketestjob: Phoenix/job/MashTub.Net/job/MashTub.SmokeTests/job/master/
+    sdkversion: "${#stage( 'FindImage' )[\"context\"][\"amiDetails\"][0][\"tag\"]}"
     gcrrepo: phoenix-177420/phoenix-mashtub2
     gcrimage: us.gcr.io/phoenix-177420/phoenix-mashtub2
   metadata:


### PR DESCRIPTION
Motivation
---
We need to be able to run smoketests with the appropriate sdk version in spinnaker/jenkins

Modifications
---
Update the pipeline config to query the sdk version and pass it to the jenkins job

https://centeredge.atlassian.net/browse/PHNX-2155
