### PR TITLE
Add requests and limits for nginx (DO-445)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -427,13 +427,17 @@ stages:
           repository: phoenix-177420/nginx-proxy
           tag: "8"
         imagePullPolicy: IFNOTPRESENT
-        limits: {}
+        limits:
+          cpu: "{{ maxcpu }}"
+          memory: "{{ maxmem }}"
         name: phoenix-177420-nginx-proxy
         ports:
         - containerPort: 80
           name: http
           protocol: TCP
-        requests: {}
+        requests: 
+          cpu: "{{ requestcpu }}"
+          memory: "{{ requestmem }}"
         volumeMounts: []
       deployment:
         deploymentStrategy:


### PR DESCRIPTION
Motivation
----------
Horizontal pod autoscaling is not working correctly dur to the fact that
requests and limits have not been set on the nginx sidecars. This data is
required for the stats to be reported and used.

Modifications
-------------
Added requests and limits for nginx

Results
-------
Stats are returned.

https://centeredge.atlassian.net/browse/DO-445
