### PR TITLE
Fix Mashtub template for size and qty (DO-445)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -239,9 +239,9 @@ stages:
     - account: phoenix
       application: "{{ application }}"
       capacity:
-        desired: 1
+        desired: 2
         max: 9
-        min: 3
+        min: 2
       cloudProvider: kubernetes
       containers:
       - args: []
@@ -325,13 +325,17 @@ stages:
           repository: phoenix-177420/nginx-proxy
           tag: "8"
         imagePullPolicy: IFNOTPRESENT
-        limits: {}
+        limits:
+          cpu: "{{ maxcpu }}"
+          memory: "{{ maxmem }}"
         name: phoenix-177420-nginx-proxy
         ports:
         - containerPort: 80
           name: http
           protocol: TCP
-        requests: {}
+        requests: 
+          cpu: "{{ requestcpu }}"
+          memory: "{{ requestmem }}"
         volumeMounts: []
       deployment:
         deploymentStrategy:


### PR DESCRIPTION
Motivation
----------
The Mashtub pipeline needed the same min/desired number and the
requests and limits put on the production template

Modifications
-------------
Changed the min and desired number of instances to 2
Added requests and limits to the nginx container.

Results
-------
The pods are deployed as expected.

https://centeredge.atlassian.net/browse/DO-445
