### PR TITLE
Adjust Alerts (PHNX-2236)

### DIFF
--- a/templates/cluster-cleanup-template.yml
+++ b/templates/cluster-cleanup-template.yml
@@ -14,8 +14,6 @@ configuration:
     name: slack0
     type: slack
     when:
-    - pipeline.starting
-    - pipeline.complete
     - pipeline.failed
   triggers:
   - cronExpression: 0 0 3 1/1 * ? *

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -234,6 +234,17 @@ stages:
   inject: {}
   name: Smoke Test
   type: jenkins
+  notifications:
+    - address: phoenixdev-ci
+      level: stage
+      message:
+        stage.failed:
+          text: "Smoke Tests Failed...@channel"
+      name: slackSmokeTestsFailed
+      type: slack
+      when:
+      - stage.failed
+    sendNotifications: true
 - config:
     clusters:
     - account: phoenix

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -276,6 +276,17 @@ stages:
   inject: {}
   name: Smoke Test
   type: jenkins
+  notifications:
+    - address: phoenixdev-ci
+      level: stage
+      message:
+        stage.failed:
+          text: "Smoke Tests Failed...@channel"
+      name: slackSmokeTestsFailed
+      type: slack
+      when:
+      - stage.failed
+    sendNotifications: true
 - config:
     clusters:
     - account: phoenix


### PR DESCRIPTION
Motivation
---
Too many alerts when running cleanup pipelines. Not enough alerts when Smoke Tests fail (as in no alerts are sent...)

Modification
---
- Only send alerts when cleanup pipelines fail
- Start sending alerts when Smoke Test stages fail in production

https://centeredge.atlassian.net/browse/PHNX-2236
