### PR TITLE
Fail Pipeline When Smoke Tests Fail (PHNX-2271)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -219,9 +219,9 @@ stages:
   name: FindImage
   type: findImage
 - config:
-    completeOtherBranchesThenFail: true
+    completeOtherBranchesThenFail: false
     continuePipeline: true
-    failPipeline: true
+    failPipeline: false
     job: "{{ smoketestjob }}"
     master: primary-jenkins
     parameters:
@@ -234,16 +234,6 @@ stages:
   inject: {}
   name: Smoke Test
   type: jenkins
-  notifications:
-    - address: phoenixdev-ci
-      level: stage
-      message:
-        stage.failed:
-          text: "Smoke Tests Failed...@channel"
-      name: slackSmokeTestsFailed
-      type: slack
-      when:
-      - stage.failed
 - config:
     clusters:
     - account: phoenix
@@ -496,3 +486,16 @@ stages:
   inject: {}
   name: Publish Failed Event
   type: datadogEvent
+- config:
+    preconditions:
+    - context:
+        expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
+      failPipeline: true
+      type: expression
+  dependsOn:
+  - destroy-staging-server-group
+  id: check-smoketest-failure
+  inheritanceControl: {}
+  inject: {}
+  name: Check Smoke Test Failure
+  type: checkPreconditions

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -219,9 +219,9 @@ stages:
   name: FindImage
   type: findImage
 - config:
-    completeOtherBranchesThenFail: false
+    completeOtherBranchesThenFail: true
     continuePipeline: true
-    failPipeline: false
+    failPipeline: true
     job: "{{ smoketestjob }}"
     master: primary-jenkins
     parameters:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -589,10 +589,20 @@ stages:
   name: Publish Failed Event
   type: datadogEvent
 - config:
+    failOnFailedExpressions: true
+    notifications:
+    - address: '#phoenixdev-ci'
+      level: stage
+      type: slack
+      message:
+      stage.failed:
+        text: "Smoke Tests Failure for {{ application }}...@channel"
+      when:
+      - stage.failed
     preconditions:
     - context:
         expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
-      failPipeline: true
+      failPipeline: false
       type: expression
   dependsOn:
   - destroy-staging-server-group

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -277,11 +277,11 @@ stages:
   name: Smoke Test
   type: jenkins
   notifications:
-    - address: phoenixdev-ci
+    - address: "#phoenixdev-ci"
       level: stage
       message:
         stage.failed:
-          text: "Smoke Tests Failed...@channel"
+          text: "Smoke Tests Failed for {{ application }}...@channel"
       name: slackSmokeTestsFailed
       type: slack
       when:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -595,7 +595,7 @@ stages:
       failPipeline: true
       type: expression
   dependsOn:
-  - phoenix-scriptedpipelinetest-smoketest
+  - destroy-staging-server-group
   id: check-smoketest-failure
   inheritanceControl: {}
   inject: {}

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -263,7 +263,7 @@ stages:
   name: Wait for ALB Health Checks
   type: wait
 - config:
-    completeOtherBranchesThenFail: true
+    completeOtherBranchesThenFail: false
     continuePipeline: true
     failPipeline: false
     job: "{{ smoketestjob }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -265,7 +265,7 @@ stages:
 - config:
     completeOtherBranchesThenFail: true
     continuePipeline: true
-    failPipeline: true
+    failPipeline: false
     job: "{{ smoketestjob }}"
     master: primary-jenkins
     parameters: "{{ smoketestparams }}"
@@ -276,16 +276,6 @@ stages:
   inject: {}
   name: Smoke Test
   type: jenkins
-  notifications:
-    - address: "#phoenixdev-ci"
-      level: stage
-      message:
-        stage.failed:
-          text: "Smoke Tests Failed for {{ application }}...@channel"
-      name: slackSmokeTestsFailed
-      type: slack
-      when:
-      - stage.failed
 - config:
     clusters:
     - account: phoenix
@@ -598,3 +588,16 @@ stages:
   inject: {}
   name: Publish Failed Event
   type: datadogEvent
+- config:
+    preconditions:
+    - context:
+        expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
+      failPipeline: true
+      type: expression
+  dependsOn:
+  - deploy1
+  id: phoenix-scriptedpipelinetest-smoketest
+  inheritanceControl: {}
+  inject: {}
+  name: Check for Smoke Test Failure
+  type: checkPreconditions

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -589,20 +589,10 @@ stages:
   name: Publish Failed Event
   type: datadogEvent
 - config:
-    failOnFailedExpressions: true
-    notifications:
-    - address: '#phoenixdev-ci'
-      level: stage
-      type: slack
-      message:
-      stage.failed:
-        text: "Smoke Tests Failure for {{ application }}...@channel"
-      when:
-      - stage.failed
     preconditions:
     - context:
         expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
-      failPipeline: false
+      failPipeline: true
       type: expression
   dependsOn:
   - destroy-staging-server-group

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -263,9 +263,9 @@ stages:
   name: Wait for ALB Health Checks
   type: wait
 - config:
-    completeOtherBranchesThenFail: false
+    completeOtherBranchesThenFail: true
     continuePipeline: true
-    failPipeline: false
+    failPipeline: true
     job: "{{ smoketestjob }}"
     master: primary-jenkins
     parameters: "{{ smoketestparams }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -595,9 +595,9 @@ stages:
       failPipeline: true
       type: expression
   dependsOn:
-  - deploy1
-  id: phoenix-scriptedpipelinetest-smoketest
+  - phoenix-scriptedpipelinetest-smoketest
+  id: check-smoketest-failure
   inheritanceControl: {}
   inject: {}
-  name: Check for Smoke Test Failure
+  name: Check Smoke Test Failure
   type: checkPreconditions


### PR DESCRIPTION
Motivation
---
Currently when Smoke Tests fail, the pipeline still completes successful without an error notification. We'd like the pipeline to send a fail notification when the smoke test stage fails.

Modification
---
- Added a new Stage that checks for Smoke Test Failures after all cleanup has completed
- If Smoke Tests fail, the pipeline fails

https://centeredge.atlassian.net/browse/PHNX-2271
