### PR TITLE
BUGFIX False Smoke Test Fail Check (PHNX-2282)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -487,9 +487,12 @@ stages:
   name: Publish Failed Event
   type: datadogEvent
 - config:
+    stageEnabled:
+      expression: "#stage('Smoke Test')['context']['buildInfo']['result']!='SUCCESS'"
+      type: expression
     preconditions:
     - context:
-        expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
+        expression: "#stage('Smoke Test')['context']['buildInfo']['result']"
       failPipeline: true
       type: expression
   dependsOn:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -10,9 +10,7 @@ configuration:
     level: pipeline
     message:
       pipeline.failed:
-        text: 
-          expression: "Pipeline Failure...@channel"
-          type: expression
+        text: "Pipeline Failure...@channel"
     name: slack0
     type: slack
     when:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -11,7 +11,7 @@ configuration:
     message:
       pipeline.failed:
         text: 
-          expression: "Pipeline Failure...Smoke Test Results: #stage('Smoke Test')['context']['buildInfo']['testResults']['failCount'] of #stage('Smoke Test')['context']['buildInfo']['testResults']['totalCount']"
+          expression: "Pipeline Failure...@channel"
           type: expression
     name: slack0
     type: slack

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -10,7 +10,7 @@ configuration:
     level: pipeline
     message:
       pipeline.failed:
-        text: "Pipeline Failure...@channel"
+        text: "Pipeline Failure...Smoke Test Results: #stage('Smoke Test')['context']['buildInfo']['testResults']"
     name: slack0
     type: slack
     when:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -591,7 +591,7 @@ stages:
 - config:
     preconditions:
     - context:
-        expression: "#stage('Smoke Test')['outputs']['buildInfo']['result']=='FAILURE'"
+        expression: "#stage('Smoke Test')['context']"
       failPipeline: true
       type: expression
   dependsOn:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -591,7 +591,7 @@ stages:
 - config:
     preconditions:
     - context:
-        expression: "#stage('Smoke Test')['context']"
+        expression: "#stage('Smoke Test')['context']['buildInfo']['result']"
       failPipeline: true
       type: expression
   dependsOn:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -591,7 +591,7 @@ stages:
 - config:
     preconditions:
     - context:
-        expression: "#stage('Smoke Test')['context']['buildInfo']['result']!='SUCCESS'"
+        expression: "#stage('Smoke Test')['outputs']['buildInfo']['result']=='FAILURE'"
       failPipeline: true
       type: expression
   dependsOn:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -10,7 +10,9 @@ configuration:
     level: pipeline
     message:
       pipeline.failed:
-        text: "Pipeline Failure...Smoke Test Results: #stage('Smoke Test')['context']['buildInfo']['testResults']"
+        text: 
+          expression: "Pipeline Failure...Smoke Test Results: #stage('Smoke Test')['context']['buildInfo']['testResults']['failCount'] of #stage('Smoke Test')['context']['buildInfo']['testResults']['totalCount']"
+          type: expression
     name: slack0
     type: slack
     when:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -589,6 +589,9 @@ stages:
   name: Publish Failed Event
   type: datadogEvent
 - config:
+    stageEnabled:
+      expression: "#stage('Smoke Test')['context']['buildInfo']['result']!='SUCCESS'"
+      type: expression
     preconditions:
     - context:
         expression: "#stage('Smoke Test')['context']['buildInfo']['result']"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -591,7 +591,7 @@ stages:
 - config:
     preconditions:
     - context:
-        expression: '"#stage(''Smoke Test'')[''context''][''buildInfo''][''result'']!=''SUCCESS''"'
+        expression: "#stage('Smoke Test')['context']['buildInfo']['result']!='SUCCESS'"
       failPipeline: true
       type: expression
   dependsOn:


### PR DESCRIPTION
Motivation
---
The final stage that checks for smoke test failures is returning a false positive on successful runs of the smoke tests.

Modification
---
- Updated the stage that fails the pipeline so it's only enabled when the smoke test stage fails
- Dump the output of the smoke test stage build result so it's in the JSON source in spinnaker

https://centeredge.atlassian.net/browse/PHNX-2282
