### PR TITLE
Add Mappings API environment variables (PHNX-2414)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -83,6 +83,11 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             configMapSource:
+              configMapName: mappings-api
+              key: url
+          name: Mappings__Host
+        - envSource:
+            configMapSource:
               configMapName: productcatalogs-api
               key: url
           name: ProductCatalogs__Host

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -77,6 +77,11 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             configMapSource:
+              configMapName: mappings-api
+              key: url
+          name: Mappings__Host
+        - envSource:
+            configMapSource:
               configMapName: productcatalogs-api
               key: url
           name: ProductCatalogs__Host


### PR DESCRIPTION
Motivation
------------
Importing waivers from Webstore 2 will require getting the SiteId for a business entity from the Mappings service and we need to add the mappings load balancer to an environment variable in the deployment pipelines used by Spinnaker.

Modifications
---------------
Added environment variables to the production and smoke test pipeline templates for the mapping service api.

https://centeredge.atlassian.net/browse/PHNX-2414
