### PR TITLE
StatsD Sample Rate 1 (PHNX-2603)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -59,7 +59,7 @@ variables:
   defaultValue: 1024Mi
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 100
+  defaultValue: 1
 - name: sdkversion
   description: The sdk version to use when testing
   defaultValue: "${#stage( 'FindImage' )['context']['amiDetails'][0]['tag']} }"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -63,7 +63,7 @@ variables:
   defaultValue: 1024Mi
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 100
+  defaultValue: 1
 stages:
 - config:
     clusters:

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -25,7 +25,7 @@ variables:
   description: The annotations to assign to pods
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 100 
+  defaultValue: 1
 stages:
 - config:
     clusters:


### PR DESCRIPTION
Motivation
---
Loggly indicates the value 100 is invalid as a sample rate. Datadog documentation shows 50% sampling would be 0.5 - so sampling 100% should probably use the value 1

https://docs.datadoghq.com/developers/faq/dog-statsd-sample-rate-parameter-explained/

Modification
---
- Set the statsD default sample rate to 1

https://centeredge.atlassian.net/browse/PHNX-2603
