### PR TITLE
Add Business Entity Service pod annotations (PHNX-2618)

### DIFF
--- a/configs/businessentities/businessentities-config.yml
+++ b/configs/businessentities/businessentities-config.yml
@@ -15,6 +15,7 @@ pipeline:
     smoketestjob: Phoenix/job/Services/job/Phoenix.Service.BusinessEntities/job/Phoenix.Service.BusinessEntities.Smoke
     gcrrepo: phoenix-177420/phoenix-service-businessentities
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-businessentities
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixBusEntSvc }"
   metadata:
     description: The Business Entities Production Pipeline Config
     name: BusinessEntities-Production

--- a/configs/businessentities/tempsmoketest-config.yml
+++ b/configs/businessentities/tempsmoketest-config.yml
@@ -11,6 +11,7 @@ pipeline:
     clustername: businessentities-staging-temp
     gcrrepo: phoenix-177420/phoenix-service-businessentities
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-businessentities:latest
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixBusEntSvc }"
   metadata:
     description: A Temporary Smoke Test Configuration
     name: BusinessEntities-TempSmokeTest


### PR DESCRIPTION
Motivation
------------
Business Entity microservice pods need a special annotation to allow them to assume a role which gives them access to S3 buckets.

Modifications
---------------
Added pod annotations for Business Entities service to have IAM roles.

https://centeredge.atlassian.net/browse/PHNX-2618
