### PR TITLE
Update Nginx Proxy image to v12 (PHNX-2621)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -146,10 +146,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:11
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "11"
+          tag: "12"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -320,10 +320,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:11
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "11"
+          tag: "12"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -217,10 +217,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:11
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "11"
+          tag: "12"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -442,10 +442,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:11
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "11"
+          tag: "12"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -186,10 +186,10 @@ stages:
           value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:11
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "11"
+          tag: "12"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
Updates have been made to the nginx proxy image to fix 415 errors when uploading waiver import CSVs and the spinnaker pipeline needs to be updated to use the new nginx proxy image.

Modifications
---------------
Updated Nginx Proxy version to v12.

https://centeredge.atlassian.net/browse/PHNX-2621
