### PR TITLE
Update nginx proxy to v13 (PHNX-2622)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -146,10 +146,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "12"
+          tag: "13"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -320,10 +320,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "12"
+          tag: "13"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -217,10 +217,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "12"
+          tag: "13"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -442,10 +442,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "12"
+          tag: "13"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -186,10 +186,10 @@ stages:
           value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:12
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-9-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "12"
+          tag: "PR-9-1"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -186,10 +186,10 @@ stages:
           value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PR-9-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PR-9-1"
+          tag: "13"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
Nginx proxy has been updated to fix issues with bulk waiver imports and spinnaker pipelines need to be updated to use the new image.

Modifications
---------------
Updated the Nginx proxy version to v13.

https://centeredge.atlassian.net/browse/PHNX-2622
