### PR TITLE
Added JwtOptions Secret to Templates (PHNX-2643)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -82,6 +82,11 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            secretSource:
+              key: secret
+              secretName: jwt-options
+          name: JwtOptions__Secret
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -256,6 +261,11 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            secretSource:
+              key: secret
+              secretName: jwt-options
+          name: JwtOptions__Secret
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -120,6 +120,11 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            secretSource:
+              key: secret
+              secretName: jwt-options
+          name: JwtOptions__Secret
         imageDescription:
           account: gcr-phoenix
           imageId: "{{ gcrimage }}"


### PR DESCRIPTION
Motivation
---
We need to be able to pass the k8s Jwt secret into the environment variables for MT2

Modifications
---
Added the environment variable mapping configuration to the MT template and the temp smoke tests template

https://centeredge.atlassian.net/browse/PHNX-2643
