### PR TITLE
Updated MashTub Template to include RabbitMQ config settings(PHNX-2646)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -87,6 +87,21 @@ stages:
               key: secret
               secretName: jwt-options
           name: JwtOptions__Secret
+        - envSource:
+            configMapSource:
+              configMapName: rabbitmq
+              key: host
+          name: RabbitMQ__Hosts__0__Host
+        - envSource:
+            configMapSource:
+              configMapName: rabbitmq
+              key: username
+          name: RabbitMQ__Username
+        - envSource:
+            secretSource:
+              key: default-pass
+              secretName: rabbitmq-config
+          name: RabbitMQ__Password
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -266,6 +281,21 @@ stages:
               key: secret
               secretName: jwt-options
           name: JwtOptions__Secret
+        - envSource:
+            configMapSource:
+              configMapName: rabbitmq
+              key: host
+          name: RabbitMQ__Hosts__0__Host
+        - envSource:
+            configMapSource:
+              configMapName: rabbitmq
+              key: username
+          name: RabbitMQ__Username
+        - envSource:
+            secretSource:
+              key: default-pass
+              secretName: rabbitmq-config
+          name: RabbitMQ__Password
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true


### PR DESCRIPTION
Motivation
----
RabbitMQ is now being used by MashTub and needs config settings for it to properly work as intended

Modifications
----
Added RabbitMQ settings for the following template:
* `templates/mt-production-template.yml`

Result
----
The MashTub Spinnaker pipeline should now have settings for RabbitMQ

https://centeredge.atlassian.net/browse/PHNX-2646
