### PR TITLE
Update MT Production template to find MT2 image (PHNX-2720)

### DIFF
--- a/configs/mashtub2/mashtub2-config.yml
+++ b/configs/mashtub2/mashtub2-config.yml
@@ -12,7 +12,7 @@ pipeline:
     stagingloadbalancer: mashtub2-staging-api
     stagingclustername: mashtub2-staging-api
     imagenamepattern: .*mashtub2.*
-    smoketestjob: Phoenix/job/MashTub.Net/job/MashTub.SmokeTests/job/master/
+    smoketestjob: Phoenix/job/MashTub.Net/job/MashTub.SmokeTests
     sdkversion: "${#stage( 'FindImage' )[\"context\"][\"amiDetails\"][0][\"tag\"]}"
     gcrrepo: phoenix-177420/phoenix-mashtub2
     gcrimage: us.gcr.io/phoenix-177420/phoenix-mashtub2

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -219,9 +219,9 @@ stages:
 - config:
     cloudProvider: kubernetes
     cloudProviderType: kubernetes
-    cluster: mashtub-prod-api
+    cluster: mashtub2-prod-api
     credentials: phoenix
-    imageNamePattern: .*mashtub.*
+    imageNamePattern: .*mashtub2.*
     namespaces:
     - default
     onlyEnabled: true


### PR DESCRIPTION
Motivation
------------
The FindImage stage of the MashTub production pipeline is currently looking for images of MT1 instead of MT2 which causes the current build number to be reported incorrectly for use in smoke tests.

Modifications
---------------
- Changed the pipeline template to look for MT2 images.
- Updated smoketestjob in the MT2 config to reflect a change made in Jenkins to the Job type for the smoke test job

https://centeredge.atlassian.net/browse/PHNX-2720
