### PR TITLE
Bump MT2 CPU Limits (PHNX-2733)

### DIFF
--- a/configs/mashtub2/mashtub2-config.yml
+++ b/configs/mashtub2/mashtub2-config.yml
@@ -16,6 +16,8 @@ pipeline:
     sdkversion: "${#stage( 'FindImage' )[\"context\"][\"amiDetails\"][0][\"tag\"]}"
     gcrrepo: phoenix-177420/phoenix-mashtub2
     gcrimage: us.gcr.io/phoenix-177420/phoenix-mashtub2
+    requestcpu: 250m
+    maxcpu: 500m
   metadata:
     description: The Mashtub2 Production Pipeline Config
     name: Mashtub2-Production


### PR DESCRIPTION
Motivation
---
We were originally requesting 1/100th a CPU for Mashtub2 and felt that was probably too light based on the amount of scaling we're seeing in MT2 over the weekends.

Recommendation was to bump to 1/4th and 1/2th for request and limit respectively.

Modification
---
- Bumped the cpu request to 250m
- Bumped the cpu max to 500m

https://centeredge.atlassian.net/browse/PHNX-2733
