### PR TITLE
Fix environment vars for MS templates (PHNX-2776)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -298,6 +298,11 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             secretSource:
+              key: url
+              secretName: couchbase-primary
+          name: Couchbase__Servers__0
+        - envSource:
+            secretSource:
               key: username
               secretName: couchbase-primary
           name: Couchbase__Username

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -335,26 +335,6 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             secretSource:
-              key: clientId
-              secretName: cognito-creds
-          name: COGNITO__ClientId
-        - envSource:
-            secretSource:
-              key: clientSecret
-              secretName: cognito-creds
-          name: COGNITO__ClientSecret
-        - envSource:
-            secretSource:
-              key: poolId
-              secretName: cognito-creds
-          name: COGNITO__UserPoolId
-        - envSource:
-            secretSource:
-              key: region
-              secretName: cognito-creds
-          name: COGNITO__Region
-        - envSource:
-            secretSource:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey


### PR DESCRIPTION
Motivation
---
The Auth MS template is missing the couchbase server url and the standard template has extraneous cognito variables

Modifications
---
Added the CB env var to the auth template production deploy and removed the cognito vars from the standard template production deploy (both were already done for smoke tests)

https://centeredge.atlassian.net/browse/PHNX-2776
