### PR TITLE
Add AWS Pod annotations for AuthZ (PHNX-2784)

### DIFF
--- a/configs/authz/authorization-config.yml
+++ b/configs/authz/authorization-config.yml
@@ -15,6 +15,7 @@ pipeline:
     smoketestjob: Phoenix/job/Services/job/Phoenix.Service.Authorization/job/Phoenix.Service.Authorization.Smoke
     gcrrepo: phoenix-177420/phoenix-service-authorization
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-authorization
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixAuthenticationService }"
   metadata:
     description: The Authorization Production Pipeline Config
     name: Authorization-Production

--- a/configs/authz/tempsmoketest-config.yml
+++ b/configs/authz/tempsmoketest-config.yml
@@ -11,6 +11,7 @@ pipeline:
     clustername: authz-staging-temp
     gcrrepo: phoenix-177420/phoenix-service-authorization
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-authorization:latest
+    podAnnotations: "{ iam.amazonaws.com/role: PhoenixAuthenticationService }"
   metadata:
     description: A Temporary Smoke Test Configuration
     name: Authorization-TempSmokeTest


### PR DESCRIPTION
Motivation
------------
We recently added some Cognito calls to the AuthZ microservice, but they aren't working in production due to the lack of AWS credentials on AuthZ pods.

Modifications
---------------
Added pod annotations for authZ pods to be able to access AWS Cognito service.

https://centeredge.atlassian.net/browse/PHNX-2784
