### PR TITLE
Update templates to set waiver upload timeout variable (PHNX-2855)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -97,6 +97,11 @@ stages:
               key: default-pass
               secretName: rabbitmq-config
           name: RabbitMQ__Password
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-timeout
+              key: timeout
+            name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -286,6 +291,11 @@ stages:
               key: default-pass
               secretName: rabbitmq-config
           name: RabbitMQ__Password
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-timeout
+              key: timeout
+            name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -133,6 +133,11 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-timeout
+              key: timeout
+            name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -338,6 +343,11 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-timeout
+              key: timeout
+            name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -125,6 +125,11 @@ stages:
               key: secret
               secretName: jwt-options
           name: JwtOptions__Secret
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-timeout
+              key: timeout
+            name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           imageId: "{{ gcrimage }}"


### PR DESCRIPTION
Motivation
------------
Some waiver CSV uploads may take a long time to complete and we need to set a timeout which is long enough to allow them to finish.

Modifications
---------------
Set environment variable for waiver upload timeout which pulls its value from a k8s config map.

https://centeredge.atlassian.net/browse/PHNX-2855
