### PR TITLE
Update Nginx proxy to apply waiver upload timeouts (PHNX-2818)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -166,10 +166,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "13"
+          tag: "14"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -360,10 +360,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "13"
+          tag: "14"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -202,10 +202,10 @@ stages:
           value: "smoke.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "13"
+          tag: "14"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -412,10 +412,10 @@ stages:
           value: "prod.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "13"
+          tag: "14"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -196,10 +196,10 @@ stages:
           value: "staging.{{ application }}"
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "13"
+          tag: "14"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
Some waiver CSV uploads may take a long time and we need a way to configure longer timeouts for those endpoints.

Modifications
---------------
Updated nginx proxy to version 14 which has timeout settings for waiver upload endpoints based on environment variables.

https://centeredge.atlassian.net/browse/PHNX-2818
