### PR TITLE
Fix spacing of environment variable names for timeouts (PHNX-2867)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -101,7 +101,7 @@ stages:
             configMapSource:
               configMapName: waiver-upload-timeout
               key: timeout
-            name: WaiverUploadOptions__KeepAliveTimeout
+          name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -295,7 +295,7 @@ stages:
             configMapSource:
               configMapName: waiver-upload-timeout
               key: timeout
-            name: WaiverUploadOptions__KeepAliveTimeout
+          name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -137,7 +137,7 @@ stages:
             configMapSource:
               configMapName: waiver-upload-timeout
               key: timeout
-            name: WaiverUploadOptions__KeepAliveTimeout
+          name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -347,7 +347,7 @@ stages:
             configMapSource:
               configMapName: waiver-upload-timeout
               key: timeout
-            name: WaiverUploadOptions__KeepAliveTimeout
+          name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -129,7 +129,7 @@ stages:
             configMapSource:
               configMapName: waiver-upload-timeout
               key: timeout
-            name: WaiverUploadOptions__KeepAliveTimeout
+          name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           imageId: "{{ gcrimage }}"


### PR DESCRIPTION
Motivation
------------
YAML is picky about spacing and the name property is indented too far for `WaiverUploadOptions__KeepAliveTimeout`.

Modifications
---------------
Removed 10 spaces.

https://centeredge.atlassian.net/browse/PHNX-2867
