### PR TITLE
Add max request size environment variable (PHNX-2872)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -205,6 +205,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "smoke.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:13
@@ -420,6 +430,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:13

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -99,7 +99,7 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-timeout
+              configMapName: waiver-upload-options
               key: timeout
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -164,6 +164,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "smoke.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
@@ -293,7 +303,7 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-timeout
+              configMapName: waiver-upload-options
               key: timeout
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -358,6 +368,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:14

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -135,7 +135,7 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-timeout
+              configMapName: waiver-upload-options
               key: timeout
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -200,6 +200,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "smoke.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:14
@@ -345,7 +355,7 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-timeout
+              configMapName: waiver-upload-options
               key: timeout
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -410,6 +420,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:14

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -127,7 +127,7 @@ stages:
           name: JwtOptions__Secret
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-timeout
+              configMapName: waiver-upload-options
               key: timeout
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -194,6 +194,16 @@ stages:
           value: "{{ statsdSampleRate }}"
         - name: SERVICE_NAME
           value: "staging.{{ application }}"
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: timeout
+          name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: waiver-upload-options
+              key: max_size
+          name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
           imageId: us.gcr.io/phoenix-177420/nginx-proxy:14


### PR DESCRIPTION
Motivation
------------
We want to be able to change the size of the request limit for waiver uploads without needing to rebuild our nginx proxy image every time.

Modifications
---------------
- Renamed waiver-upload-timeout configmap to waiver-upload-options to reflect changes in the name of the configmap.
- Added missing timeout environment variable to nginx proxy.
- Added request size limit environment variable to nginx proxy.

https://centeredge.atlassian.net/browse/PHNX-2872
