### PR TITLE
Update to nginx proxy v18 (PHNX-2876)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -217,10 +217,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -442,10 +442,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -176,10 +176,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -380,10 +380,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -212,10 +212,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -432,10 +432,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -206,10 +206,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:17
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "17"
+          tag: "18"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
Nginx proxy v17 image was broken and not properly substituting waiver upload option environment variables.

Modifications
---------------
Updated all nginx-proxy references to v18.

https://centeredge.atlassian.net/browse/PHNX-2876
