### PR TITLE
Add podAnnotationsStaging Variable (PHNX-2892)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -45,7 +45,11 @@ variables:
 - name: podAnnotations
   type: object
   defaultValue: {}
-  description: The annotations to assign to pods
+  description: The annotations to assign to production pods
+- name: podAnnotationsStaging
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to staging pods
 - name: product
   description: The name of the product this deployment belongs to
   defaultValue: Phoenix

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -41,7 +41,11 @@ variables:
 - name: podAnnotations
   type: object
   defaultValue: {}
-  description: The annotations to assign to pods
+  description: The annotations to assign to production pods
+- name: podAnnotationsStaging
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to staging pods
 - name: product
   description: The name of the product this deployment belongs to
   defaultValue: Phoenix

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -45,7 +45,11 @@ variables:
 - name: podAnnotations
   type: object
   defaultValue: {}
-  description: The annotations to assign to pods
+  description: The annotations to assign to production pods
+- name: podAnnotationsStaging
+  type: object
+  defaultValue: {}
+  description: The annotations to assign to staging pods
 - name: product
   description: The name of the product this deployment belongs to
   defaultValue: Phoenix


### PR DESCRIPTION
Motivation
---
To better monitor and filter our pods, we're adding a new podAnnotationsStaging variable so we can better distinguish between staging and production pods in Datadog.

This is the first of a multi-step process for getting the new variable into use.

Modification
---
- Added a new podAnnotationsStaging variable

https://centeredge.atlassian.net/browse/PHNX-2892
