### PR TITLE
Use Nginx proxy with correct StatsD rate (PHNX-2926)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -221,10 +221,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -419,7 +419,7 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []
@@ -446,10 +446,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"
@@ -459,7 +459,7 @@ stages:
         - containerPort: 80
           name: http
           protocol: TCP
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -180,10 +180,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -357,7 +357,7 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []
@@ -384,10 +384,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"
@@ -397,7 +397,7 @@ stages:
         - containerPort: 80
           name: http
           protocol: TCP
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -216,10 +216,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -409,7 +409,7 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []
@@ -436,10 +436,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"
@@ -449,7 +449,7 @@ stages:
         - containerPort: 80
           name: http
           protocol: TCP
-        requests: 
+        requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"
         volumeMounts: []

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -206,10 +206,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:18
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "18"
+          tag: "19"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
----------
Current values in DataDog are being scaled by 100x.

Modification
------------
Change to build 19 of the Nginx proxy.

https://centeredge.atlassian.net/browse/PHNX-2926
