### PR TITLE
Correct default StatsD rate (PHNX-2926)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -67,7 +67,7 @@ variables:
   defaultValue: 1024Mi
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 1
+  defaultValue: 100
 stages:
 - config:
     clusters:

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -63,7 +63,7 @@ variables:
   defaultValue: 1024Mi
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 1
+  defaultValue: 100
 - name: sdkversion
   description: The sdk version to use when testing
   defaultValue: "${#stage( 'FindImage' )['context']['amiDetails'][0]['tag']} }"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -67,7 +67,7 @@ variables:
   defaultValue: 1024Mi
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 1
+  defaultValue: 100
 stages:
 - config:
     clusters:

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -25,7 +25,7 @@ variables:
   description: The annotations to assign to pods
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
-  defaultValue: 1
+  defaultValue: 100
 stages:
 - config:
     clusters:


### PR DESCRIPTION
Motivation
----------
The StatsD rate should be 100 to log 100% by default, not 1 for 1%.
Especially since at low request volumes this skews values significantly.

https://centeredge.atlassian.net/browse/PHNX-2926
