### PR TITLE
Update nginx proxy to only log non-success status (PHNX-2956)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -221,10 +221,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -446,10 +446,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -221,10 +221,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -446,10 +446,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -180,10 +180,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -384,10 +384,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -180,10 +180,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -384,10 +384,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -218,10 +218,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -438,10 +438,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -218,10 +218,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -438,10 +438,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -208,10 +208,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "PHNX-2969-1"
+          tag: "23"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -208,10 +208,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:PHNX-2969-1
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "PHNX-2969-1"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
Our Nginx proxy is currently logging every 2xx/3xx response to the console which is overflowing our limits in loggly.  We need to update this to exclude successful requests.

Modifications
---------------
Updated nginx-proxy image to v23 which only logs non-success status codes.

https://centeredge.atlassian.net/browse/PHNX-2956
