### PR TITLE
Added StatsD Metric Variables For RED Metrics In Waiver Svc (PHNX-3010)

### DIFF
--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -172,6 +172,12 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
         - envSource:

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -53,6 +53,12 @@ stages:
         envVars:
         - name: ASPNETCORE_ENVIRONMENT
           value: Production
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             configMapSource:
               configMapName: businessentities-api
@@ -172,12 +178,6 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
-        - name: Statsd__Config__StatsdServerName
-          envSource:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: Statsd__Enabled
-          value: "true"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
         - envSource:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -204,6 +204,12 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - name: SERVICE_NAME
           value: "smoke.{{ application }}"
         - envSource:
@@ -424,6 +430,12 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
         - envSource:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -80,6 +80,12 @@ stages:
         envVars:
         - name: ASPNETCORE_ENVIRONMENT
           value: Staging
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             configMapSource:
               configMapName: businessentities-api
@@ -204,12 +210,6 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
-        - name: Statsd__Config__StatsdServerName
-          envSource:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: Statsd__Enabled
-          value: "true"
         - name: SERVICE_NAME
           value: "smoke.{{ application }}"
         - envSource:
@@ -308,6 +308,12 @@ stages:
         envVars:
         - name: ASPNETCORE_ENVIRONMENT
           value: Production
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             configMapSource:
               configMapName: businessentities-api
@@ -430,12 +436,6 @@ stages:
               fieldPath: status.hostIP
         - name: STATSD_SAMPLE_RATE
           value: "{{ statsdSampleRate }}"
-        - name: Statsd__Config__StatsdServerName
-          envSource:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: Statsd__Enabled
-          value: "true"
         - name: SERVICE_NAME
           value: "prod.{{ application }}"
         - envSource:


### PR DESCRIPTION
Motivation
----
* There are new environment variables for the waiver service:
  * `Statsd__Enabled`
  * `Statsd__Config__StatsdServerName`
* We need to set those values for the spinnaker pipeline

Modifications
----
* Updated production template to include the new fields and values
* Updated the waiver config to include the new fields and values

Note: The variable names were taken from the new setting values for the RED Metric update in waiver service, found here: https://github.com/CenterEdge/Phoenix.Service.Waivers/pull/99

Result
----
The environment variables should be applied to the new waiver service RED Metric updates when it is deployed

https://centeredge.atlassian.net/browse/PHNX-3010
