### PR TITLE
Shrink jobs cluster after deployment (PHNX-3017)

### DIFF
--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -268,3 +268,20 @@ stages:
   inject: {}
   name: Disable Cluster
   type: disableCluster
+- config:
+    allowDeleteActive: false
+    cloudProvider: kubernetes
+    cloudProviderType: kubernetes
+    cluster: "{{ jobsclustername }}"
+    credentials: phoenix
+    namespaces:
+    - default
+    retainLargerOverNewer: "false"
+    shrinkToSize: 2
+  dependsOn:
+  - phoenix-production-jobs-disablecluster
+  id: phoenix-production-jobs-shrinkcluster
+  inheritanceControl: {}
+  inject: {}
+  name: Shrink Cluster
+  type: shrinkCluster


### PR DESCRIPTION
Motivation
------------
The current Waivers pipeline does not automatiaclly reduce the size of the `waivers-jobs-api` cluster, which results in excess server groups being left running in that cluster after each deployment.

Modifications
---------------
Added a step to the Waivers pipeline to shrink the jobs cluster after disabling the old server group.

https://centeredge.atlassian.net/browse/PHNX-3017
