### PR TITLE
Add Shawarma support to microservices (ARCH-56)

### DIFF
--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -21,6 +21,7 @@ pipeline:
     podAnnotationsStaging: "{ iam.amazonaws.com/role: PhoenixWaiversSvc, environment: staging }"
     podAnnotationsProdJobs: "{ iam.amazonaws.com/role: PhoenixWaiversSvc, environment: prod }"
     maxmem: 4096Mi
+    shawarmaEnabled: true
   metadata:
     description: The Waivers Production Pipeline Config
     name: Waivers-Production
@@ -226,7 +227,14 @@ stages:
       - "{{ jobsloadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations: "{{ podAnnotationsProdJobs }}"
+      podAnnotations: |
+        {% if not shawarmaEnabled -%}
+        {{ podAnnotationsProdJobs }}
+        {% elif podAnnotationsProdJobs == '{}' -%}
+        {"shawarma.centeredge.io/service-name": "{{ jobsloadbalancer }}"}
+        {% else -%}
+        {{ podAnnotationsProdJobs.substring(0, podAnnotationsProdJobs.length()-1) }}, "shawarma.centeredge.io/service-name": "{{ jobsloadbalancer }}"}
+        {%- endif %}
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -68,6 +68,14 @@ variables:
 - name: statsdSampleRate
   description: The percentage of requests to log to statsd. Set to 0 to disable
   defaultValue: 100
+- name: shawarmaEnabled
+  description: Enables the Shawarma sidecar injector, linked to the configured load balancer
+  defaultValue: false
+  type: boolean
+- name: shawarmaStaging
+  description: Enables the Shawarma sidecar injector for staging, only applicable if shawarmaEnabled is also true
+  defaultValue: true
+  type: boolean
 stages:
 - config:
     clusters:
@@ -254,7 +262,14 @@ stages:
       - "{{ stagingloadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations: "{{ podAnnotationsStaging }}"
+      podAnnotations: |
+        {% if not shawarmaEnabled or not shawarmaStaging -%}
+        {{ podAnnotationsStaging }}
+        {% elif podAnnotationsStaging == '{}' -%}
+        {"shawarma.centeredge.io/service-name": "{{ stagingloadbalancer }}"}
+        {% else -%}
+        {{ podAnnotationsStaging.substring(0, podAnnotationsStaging.length()-1) }}, "shawarma.centeredge.io/service-name": "{{ stagingloadbalancer }}"}
+        {%- endif %}
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}
@@ -484,7 +499,14 @@ stages:
       - "{{ loadbalancer }}"
       namespace: default
       nodeSelector: {}
-      podAnnotations: "{{ podAnnotations }}"
+      podAnnotations: |
+        {% if not shawarmaEnabled -%}
+        {{ podAnnotations }}
+        {% elif podAnnotations == '{}' -%}
+        {"shawarma.centeredge.io/service-name": "{{ loadbalancer }}"}
+        {% else -%}
+        {{ podAnnotations.substring(0, podAnnotations.length()-1) }}, "shawarma.centeredge.io/service-name": "{{ loadbalancer }}"}
+        {%- endif %}
       provider: kubernetes
       region: default
       replicaSetAnnotations: {}


### PR DESCRIPTION
Motivation
----------
Use a single variable on the pipeline template to apply the Shawarma
annotations to deployed pods.

Modifications
-------------
Added "shawarmaEnabled" and "shawarmaStaging" variables to the
microservice template, which automatically adds the annotations.

Set the Waivers microservice to have Shawarma enabled, and also updated
the special configuration for the Jobs processor to apply the Shawarma
annotation.

https://centeredge.atlassian.net/browse/ARCH-56
