### PR TITLE
Add StatsD config to MashTub pipeline (PHNX-3144)

### DIFF
--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -81,6 +81,12 @@ stages:
           value: Staging
         - name: ASPNETCORE_URLS
           value: http://localhost:8080/
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             secretSource:
               key: key
@@ -285,6 +291,12 @@ stages:
           value: Production
         - name: ASPNETCORE_URLS
           value: http://localhost:8080/
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             secretSource:
               key: key


### PR DESCRIPTION
Motivation
------------
We want RED metrics reported for MashTub requests.

Modifications
---------------
Added required StatsD configuration environment variables to enable StatsD reporting in MashTub.

https://centeredge.atlassian.net/browse/PHNX-3144
