### PR TITLE
Enable StatsD for auth pipelines (PHNX-3222)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -80,6 +80,12 @@ stages:
         envVars:
         - name: ASPNETCORE_ENVIRONMENT
           value: Staging
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             configMapSource:
               configMapName: businessentities-api
@@ -305,6 +311,12 @@ stages:
         envVars:
         - name: ASPNETCORE_ENVIRONMENT
           value: Production
+        - name: Statsd__Config__StatsdServerName
+          envSource:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: Statsd__Enabled
+          value: "true"
         - envSource:
             configMapSource:
               configMapName: businessentities-api


### PR DESCRIPTION
Motivation
------------
We want to have metrics enabled for AuthN/AuthZ services.

Modifications
---------------
Set StatsD environment variables in AuthN/AuthZ pipeline.

https://centeredge.atlassian.net/browse/PHNX-3222
