### PR TITLE
Update liveness probes to use ready checks (PHNX-3284)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -167,7 +167,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:
@@ -400,7 +400,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -126,7 +126,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:
@@ -338,7 +338,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -172,7 +172,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -407,7 +407,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -146,7 +146,7 @@ stages:
             execAction:
               commands: []
             httpGetAction:
-              path: /health
+              path: /health?type=ready
               port: 80
               uriScheme: HTTP
             tcpSocketAction:


### PR DESCRIPTION
Motivation
------------
Kubernetes will only restart a pod which is failing the liveness probe, and not a pod which is failing the readiness probe.  We currently have the liveness probes configured to hit `/health` where the readiness probes hit `/health?type=ready`.  The `/health` endpoint does not attempt to retrieve a document from couchbase and will pass even when couchbase cannot be accessed which leaves us with pods that cannot process any real requests.

Modifications
---------------
Changed all templates liveness probes to use `/health?type=ready` to check for liveness.

https://centeredge.atlassian.net/browse/PHNX-3284
