### PR TITLE
Add Stations host environment variable (PHNX-3876)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -111,6 +111,11 @@ stages:
           name: ProductCatalogs__Host
         - envSource:
             configMapSource:
+              configMapName: stations-api
+              key: url
+          name: Stations__Host
+        - envSource:
+            configMapSource:
               configMapName: pdf-api
               key: url
           name: HtmlToPdf__Host
@@ -344,6 +349,11 @@ stages:
               configMapName: productcatalogs-api
               key: url
           name: ProductCatalogs__Host
+        - envSource:
+            configMapSource:
+              configMapName: stations-api
+              key: url
+          name: Stations__Host
         - envSource:
             configMapSource:
               configMapName: pdf-api

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -87,6 +87,11 @@ stages:
           name: ProductCatalogs__Host
         - envSource:
             configMapSource:
+              configMapName: stations-api
+              key: url
+          name: Stations__Host
+        - envSource:
+            configMapSource:
               configMapName: pdf-api
               key: url
           name: HtmlToPdf__Host


### PR DESCRIPTION
Motivation
------------
We need to be able to tell the card processing microservice where to connect when checking if a station exists.

Modifications
---------------
Added Stations__Host environment variable to configure stations host based on the K8s `stations-api` config map.

https://centeredge.atlassian.net/browse/PHNX-3876
