### PR TITLE
Cleanup Shrinks Down to 2 (PHNX-2460)

### DIFF
--- a/templates/cluster-cleanup-template.yml
+++ b/templates/cluster-cleanup-template.yml
@@ -40,7 +40,7 @@ stages:
     namespaces:
     - default
     retainLargerOverNewer: "false"
-    shrinkToSize: 1
+    shrinkToSize: 2
   id: shrinkCluster1
   inheritanceControl: {}
   inject: {}


### PR DESCRIPTION
Motivation
---
The cleanup script was not leaving a rollback cluster when running overnight which could compromise our ability to quickly respond to production issues related to a bad deployment.

Modification
---
- Adjust property shrinkToSize: 2

https://centeredge.atlassian.net/browse/PHNX-2460
