### PR TITLE
Update spinnaker pipelines to use CB ConnectionString (PHNX-4572)

### DIFF
--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -93,9 +93,9 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - name: ASPNETCORE_URLS
           value: http://localhost:8080/
         - envSource:
@@ -324,9 +324,9 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username

--- a/templates/emergency-auth-production-template.yml
+++ b/templates/emergency-auth-production-template.yml
@@ -88,9 +88,9 @@ stages:
           name: BusinessEntities__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -110,9 +110,9 @@ stages:
           name: HtmlToPdf__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -121,9 +121,9 @@ stages:
           name: HtmlToPdf__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - name: ASPNETCORE_URLS
           value: http://localhost:8080/
         - envSource:
@@ -361,9 +361,9 @@ stages:
           name: HtmlToPdf__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -40,9 +40,9 @@ stages:
           value: Staging
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - name: ASPNETCORE_URLS
           value: http://localhost:8080/
         - envSource:


### PR DESCRIPTION
Motivation
------------
To prevent K8s upgrades from causing downtime related to couchbase, we want to use DNS discovery in all of our microservices.

Modifications
---------------
Updated templates to provide the connection string property in the couchbase-primary k8s secret.

https://centeredge.atlassian.net/browse/PHNX-4572
