### PR TITLE
Remove /api/ from TriPos Transactions host path (PHNX-4626)

### DIFF
--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -331,7 +331,7 @@ stages:
         - name: TriPosCloudOptions__LaneManagementHost
           value: https://tripos.worldpay.com/cloudapi/
         - name: TriPosCloudOptions__TransactionsHost
-          value: https://tripos.worldpay.com/api/
+          value: https://tripos.worldpay.com/
         - name: Statsd__Config__StatsdServerName
           envSource:
             fieldRef:


### PR DESCRIPTION
Motivation
------------
The TriPos transactions API client includes the /api/ section of the path in the client itself, so it should not be included in the path set in the environment variable in the spinnaker pipeline.

Modifications
---------------
Removed /api/ from the TriPos Transactions Host path

https://centeredge.atlassian.net/browse/PHNX-4626
