### PR TITLE
Update Nginx proxy to v25 (PHNX-4676)

### DIFF
--- a/configs/waivers/emergency-config.yml
+++ b/configs/waivers/emergency-config.yml
@@ -188,10 +188,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -193,10 +193,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:19
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "19"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -227,10 +227,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -458,10 +458,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-auth-production-template.yml
+++ b/templates/emergency-auth-production-template.yml
@@ -222,10 +222,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-mt-production-template.yml
+++ b/templates/emergency-mt-production-template.yml
@@ -185,10 +185,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -224,10 +224,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -186,10 +186,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -396,10 +396,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -237,10 +237,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -479,10 +479,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -213,10 +213,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:23
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "23"
+          tag: "25"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
We've updated the Nginx proxy docker image to raise the error_log level from info to notice and we need to update spinnaker pipelines to make use of that new image.

Modifications
---------------
Updated all templates and configs to use nginx proxy v25 docker image

https://centeredge.atlassian.net/browse/PHNX-4676
