### PR TITLE
Update Waivers job pods to use SRV record (PHNX-4678)

### DIFF
--- a/configs/waivers/emergency-config.yml
+++ b/configs/waivers/emergency-config.yml
@@ -77,9 +77,9 @@ stages:
           name: HtmlToPdf__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -82,9 +82,9 @@ stages:
           name: HtmlToPdf__Host
         - envSource:
             secretSource:
-              key: url
+              key: connectionString
               secretName: couchbase-primary
-          name: Couchbase__Servers__0
+          name: Couchbase__ConnectionString
         - envSource:
             secretSource:
               key: username


### PR DESCRIPTION
Motivation
------------
Previously, all microservices were updated to use DnsDiscovery with the SRV record that Tom created for our couchbase cluster to prevent outages during k8s upgrades, however, the Waivers MS job pods were not updated in the config.  We want those pods to use the SRV record too.

Modifications
---------------
Updated Waivers job pods config to use SRV records for couchbase.

https://centeredge.atlassian.net/browse/PHNX-4678
