### PR TITLE
Update to v26 of nginx proxy (PHNX-4682)

### DIFF
--- a/configs/waivers/emergency-config.yml
+++ b/configs/waivers/emergency-config.yml
@@ -188,10 +188,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -193,10 +193,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -227,10 +227,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -458,10 +458,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-auth-production-template.yml
+++ b/templates/emergency-auth-production-template.yml
@@ -222,10 +222,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-mt-production-template.yml
+++ b/templates/emergency-mt-production-template.yml
@@ -185,10 +185,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -224,10 +224,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -186,10 +186,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -396,10 +396,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -237,10 +237,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -479,10 +479,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -213,10 +213,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:25
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "25"
+          tag: "26"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy


### PR DESCRIPTION
Motivation
------------
V25 of nginx proxy was broken due to improper encoding of nginx.conf file, so we need to replace with the fixed nginx proxy image (V26).

Modifications
---------------
Updated all nginx proxy images to V26.

https://centeredge.atlassian.net/browse/PHNX-4682
