### PR TITLE
Use separate env vars for timeouts (PHNX-4961)

### DIFF
--- a/configs/waivers/emergency-config.yml
+++ b/configs/waivers/emergency-config.yml
@@ -183,9 +183,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -193,10 +203,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/configs/waivers/emergency-config.yml
+++ b/configs/waivers/emergency-config.yml
@@ -114,8 +114,13 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         - name: JobOptions__ProcessBulkJobs
           value: true

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -188,9 +188,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -198,10 +208,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/configs/waivers/waivers-config.yml
+++ b/configs/waivers/waivers-config.yml
@@ -119,8 +119,13 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         - name: JobOptions__ProcessBulkJobs
           value: true

--- a/templates/auth-production-template.yml
+++ b/templates/auth-production-template.yml
@@ -217,9 +217,19 @@ stages:
           value: "smoke.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -227,10 +237,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -448,9 +458,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -458,10 +478,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-auth-production-template.yml
+++ b/templates/emergency-auth-production-template.yml
@@ -212,9 +212,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -222,10 +232,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-mt-production-template.yml
+++ b/templates/emergency-mt-production-template.yml
@@ -108,8 +108,13 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix

--- a/templates/emergency-mt-production-template.yml
+++ b/templates/emergency-mt-production-template.yml
@@ -175,9 +175,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -185,10 +195,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/emergency-mt-production-template.yml
+++ b/templates/emergency-mt-production-template.yml
@@ -114,6 +114,11 @@ stages:
         - envSource:
             configMapSource:
               configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
               key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -147,8 +147,13 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           fromTrigger: true

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -214,9 +214,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -224,10 +234,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -176,9 +176,19 @@ stages:
           value: "smoke.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -186,10 +196,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -386,9 +396,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -396,10 +416,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -115,6 +115,11 @@ stages:
         - envSource:
             configMapSource:
               configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
               key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
@@ -337,6 +342,11 @@ stages:
               configMapName: timeouts
               key: keepalive
           name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
         - envSource:
             configMapSource:
               configMapName: timeouts

--- a/templates/mt-production-template.yml
+++ b/templates/mt-production-template.yml
@@ -109,8 +109,13 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
@@ -329,8 +334,13 @@ stages:
           name: RabbitMQ__Password
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -158,9 +158,14 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
         - name: JobOptions__ProcessBulkJobs
           value: false
         imageDescription:
@@ -227,9 +232,19 @@ stages:
           value: "smoke.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -237,10 +252,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: phoenix-177420-nginx-proxy
@@ -402,9 +417,14 @@ stages:
           name: LaunchDarklyOptions__SdkKey
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
         imageDescription:
           account: gcr-phoenix
           fromTrigger: true
@@ -469,9 +489,19 @@ stages:
           value: "prod.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -479,10 +509,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits:
           cpu: "{{ maxcpu }}"

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -132,8 +132,13 @@ stages:
           name: JwtOptions__Secret
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         - name: JobOptions__ProcessBulkJobs
           value: false

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -138,6 +138,11 @@ stages:
         - envSource:
             configMapSource:
               configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
               key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         - name: JobOptions__ProcessBulkJobs

--- a/templates/tempsmoketest-template.yml
+++ b/templates/tempsmoketest-template.yml
@@ -203,9 +203,19 @@ stages:
           value: "staging.{{ application }}"
         - envSource:
             configMapSource:
-              configMapName: waiver-upload-options
-              key: timeout
-          name: WaiverUploadOptions__KeepAliveTimeout
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ConnectTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__ReadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__SendTimeout
         - envSource:
             configMapSource:
               configMapName: waiver-upload-options
@@ -213,10 +223,10 @@ stages:
           name: WaiverUploadOptions__MaxRequestSize
         imageDescription:
           account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:26
+          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
           registry: us.gcr.io
           repository: phoenix-177420/nginx-proxy
-          tag: "26"
+          tag: "27"
         imagePullPolicy: IFNOTPRESENT
         limits: {}
         name: nginx-proxy

--- a/v2/templates/PhoenixEmergencyPipelineTemplate.json
+++ b/v2/templates/PhoenixEmergencyPipelineTemplate.json
@@ -343,14 +343,34 @@
 			 "value": "prod.${ templateVariables.appName }"
 			},
 			{
-			 "envSource": {
-			  "configMapSource": {
-			   "configMapName": "waiver-upload-options",
-			   "key": "timeout",
-			   "optional": true
-			  }
-			 },
-			 "name": "WaiverUploadOptions__KeepAliveTimeout"
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ConnectTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ReadTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__SendTimeout"
 			},
 			{
 			 "envSource": {
@@ -377,10 +397,10 @@
 		   ],
 		   "imageDescription": {
 			"account": "gcr-phoenix",
-			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:26",
+			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:27",
 			"registry": "us.gcr.io",
 			"repository": "phoenix-177420/nginx-proxy",
-			"tag": "26"
+			"tag": "27"
 		   },
 		   "imagePullPolicy": "IFNOTPRESENT",
 		   "limits": {

--- a/v2/templates/PhoenixProductionPipelineTemplate.json
+++ b/v2/templates/PhoenixProductionPipelineTemplate.json
@@ -320,14 +320,34 @@
 			 "value": "smoke.${ templateVariables.appName }"
 			},
 			{
-			 "envSource": {
-			  "configMapSource": {
-			   "configMapName": "waiver-upload-options",
-			   "key": "timeout",
-			   "optional": true
-			  }
-			 },
-			 "name": "WaiverUploadOptions__KeepAliveTimeout"
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ConnectTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ReadTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__SendTimeout"
 			},
 			{
 			 "envSource": {
@@ -354,10 +374,10 @@
 		   ],
 		   "imageDescription": {
 			"account": "gcr-phoenix",
-			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:26",
+			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:27",
 			"registry": "us.gcr.io",
 			"repository": "phoenix-177420/nginx-proxy",
-			"tag": "26"
+			"tag": "27"
 		   },
 		   "imagePullPolicy": "IFNOTPRESENT",
 		   "limits": {},
@@ -650,14 +670,34 @@
 			 "value": "prod.${ templateVariables.appName }"
 			},
 			{
-			 "envSource": {
-			  "configMapSource": {
-			   "configMapName": "waiver-upload-options",
-			   "key": "timeout",
-			   "optional": true
-			  }
-			 },
-			 "name": "WaiverUploadOptions__KeepAliveTimeout"
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ConnectTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ReadTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__SendTimeout"
 			},
 			{
 			 "envSource": {
@@ -684,10 +724,10 @@
 		   ],
 		   "imageDescription": {
 			"account": "gcr-phoenix",
-			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:26",
+			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:27",
 			"registry": "us.gcr.io",
 			"repository": "phoenix-177420/nginx-proxy",
-			"tag": "26"
+			"tag": "27"
 		   },
 		   "imagePullPolicy": "IFNOTPRESENT",
 		   "limits": {

--- a/v2/templates/PhoenixSmokeTestPipelineTemplate.json
+++ b/v2/templates/PhoenixSmokeTestPipelineTemplate.json
@@ -260,14 +260,34 @@
 			 "value": "staging.${ templateVariables.appName }"
 			},
 			{
-			 "envSource": {
-			  "configMapSource": {
-			   "configMapName": "waiver-upload-options",
-			   "key": "timeout",
-			   "optional": true
-			  }
-			 },
-			 "name": "WaiverUploadOptions__KeepAliveTimeout"
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ConnectTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__ReadTimeout"
+			},
+			{
+				"envSource": {
+					"configMapSource": {
+						"configMapName": "timeouts",
+						"key": "connect_read_write",
+						"optional": true
+					}
+				},
+				"name": "TimeoutOptions__SendTimeout"
 			},
 			{
 			 "envSource": {
@@ -282,10 +302,10 @@
 		   ],
 		   "imageDescription": {
 			"account": "gcr-phoenix",
-			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:26",
+			"imageId": "us.gcr.io/phoenix-177420/nginx-proxy:27",
 			"registry": "us.gcr.io",
 			"repository": "phoenix-177420/nginx-proxy",
-			"tag": "26"
+			"tag": "27"
 		   },
 		   "imagePullPolicy": "IFNOTPRESENT",
 		   "limits": {},


### PR DESCRIPTION
Motivation
------------
We want separate environment variables to configure keepalive timeouts and connect/read/send timeouts.

Modifications
---------------
- Updated Nginx Proxy to v27
- Updated pipeline configs to set separate environment variables for connect/read/send/keepalive timeouts

https://centeredge.atlassian.net/browse/PHNX-4961
