### PR TITLE
Add WaiverUploadTimeout environment variable (PHNX-5005)

### DIFF
--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -153,6 +153,11 @@ stages:
         - envSource:
             configMapSource:
               configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
               key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         imageDescription:

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -160,6 +160,16 @@ stages:
             configMapSource:
               configMapName: timeouts
               key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
           name: WaiverUploadOptions__KeepAliveTimeout
         - envSource:
             configMapSource:
@@ -415,6 +425,16 @@ stages:
               key: key
               secretName: feature-flag-key
           name: LaunchDarklyOptions__SdkKey
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: keepalive
+          name: TimeoutOptions__KeepAliveTimeout
+        - envSource:
+            configMapSource:
+              configMapName: timeouts
+              key: connect_read_write
+          name: TimeoutOptions__WaiverUploadTimeout
         - envSource:
             configMapSource:
               configMapName: timeouts


### PR DESCRIPTION
Motivation
------------
We need to be able to specify the timeout for the AWS client separately from the keepalive timeout used by Kestrel in the Waivers MS.

Modifications
---------------
Added `TimeoutOptions__WaiverUploadTimeout` variable to MS pipelines.

https://centeredge.atlassian.net/browse/PHNX-5005
