### PR TITLE
Add Missing Namespaces (PHNX-5024)

### DIFF
--- a/templates/cluster-cleanup-template.yml
+++ b/templates/cluster-cleanup-template.yml
@@ -72,7 +72,8 @@ stages:
     credentials: phoenix
     failPipeline: false
     imageNamePattern: "{{ imagenamepattern }}"
-    namespaces: []
+    namespaces:
+    - default
     onlyEnabled: true
     selectionStrategy: NEWEST
   id: findImage2
@@ -90,7 +91,8 @@ stages:
     failPipeline: false
     interestingHealthProviderNames:
     - KubernetesService
-    namespaces: []
+    namespaces:
+    - default
     target: current_asg_dynamic
   dependsOn:
   - findImage2


### PR DESCRIPTION
Motivation
---
The cleanup pipeline template had an empty array for namespaces in two of the stages which spinnaker did not like at all.

Modification
---
- Added the namespace default to both stages where it was missing to make spinnaker happy

https://centeredge.atlassian.net/browse/PHNX-5024
