### PR TITLE
Update V2 Templates For Html Settings And Smoke Test (PHNX-5498)

### DIFF
--- a/v2/templates/PhoenixEmergencyPipelineTemplate.json
+++ b/v2/templates/PhoenixEmergencyPipelineTemplate.json
@@ -251,6 +251,15 @@
 			  }
 			 },
 			 "name": "LaunchDarklyOptions__SdkKey"
+			},
+			{
+			 "envSource": {
+				"configMapSource": {
+					"configMapName": "pdf-api",
+					"key": "url"
+				}
+			 },
+			 "name": "HtmlToPdf__Host"
 			}
 		   ],
 		   "imageDescription": {

--- a/v2/templates/PhoenixProductionPipelineTemplate.json
+++ b/v2/templates/PhoenixProductionPipelineTemplate.json
@@ -224,6 +224,15 @@
 			  }
 			 },
 			 "name": "LaunchDarklyOptions__SdkKey"
+			},
+			{
+			 "envSource": {
+				"configMapSource": {
+					"configMapName": "pdf-api",
+					"key": "url"
+				}
+			 },
+			 "name": "HtmlToPdf__Host"
 			}
 		   ],
 		   "imageDescription": {
@@ -578,6 +587,15 @@
 			  }
 			 },
 			 "name": "LaunchDarklyOptions__SdkKey"
+			},
+			{
+			 "envSource": {
+				"configMapSource": {
+					"configMapName": "pdf-api",
+					"key": "url"
+				}
+			 },
+			 "name": "HtmlToPdf__Host"
 			}
 		   ],
 		   "imageDescription": {
@@ -794,6 +812,10 @@
 		}
 	   ],
 	   "name": "Deploy Production",
+	   "stageEnabled": {
+		"expression": "#stage('Smoke Test')['context']['buildInfo']['result']=='SUCCESS'",
+		"type": "expression"
+	   },
 	   "refId": "4",
 	   "requisiteStageRefIds": [
 		"3"


### PR DESCRIPTION
Motivation
----
* There is a new html service being used by V2 Template pipelines that needs production settings passed into the running containers in production
* There is a missing smoke test failure check on the production deployment phase of the normal v2 production pipelines allowing deployments of failing builds

Modifications
----
* Updated:
  * `PhoenixEmergencyPipelineTemplate` - now includes html settings
  * `PhoenixProductionPipelineTemplate` - now includes html settings; stops production deployments on smoke test failures

Result
----
When V2 templated pipelines are configured or reconfigured, they will contain the new updated settings

https://centeredge.atlassian.net/browse/PHNX-5498
