### PR TITLE
Fix Conditional Expression Typo For SmokeTests (PHNX-5502)

### DIFF
--- a/v2/templates/PhoenixProductionPipelineTemplate.json
+++ b/v2/templates/PhoenixProductionPipelineTemplate.json
@@ -813,7 +813,7 @@
 	   ],
 	   "name": "Deploy Production",
 	   "stageEnabled": {
-		"expression": "#stage('Smoke Test')['context']['buildInfo']['result']=='SUCCESS'",
+		"expression": "#stage('Smoke Tests')['context']['buildInfo']['result']=='SUCCESS'",
 		"type": "expression"
 	   },
 	   "refId": "4",
@@ -956,7 +956,7 @@
 		"6"
 	   ],
 	   "stageEnabled": {
-		"expression": "#stage('Smoke Test')['context']['buildInfo']['result']!='SUCCESS'",
+		"expression": "#stage('Smoke Tests')['context']['buildInfo']['result']!='SUCCESS'",
 		"type": "expression"
 	   },
 	   "type": "checkPreconditions"


### PR DESCRIPTION
Motivation
----
* Smoke tests passed but builds failed... due to a Typo

Modifications
----
* Updated template to fix typo so pipelines could find correct stage for smoke tests

Result
----
Production pipelines no longer fail despite successful smoke tests

https://centeredge.atlassian.net/browse/PHNX-5502
