### PR TITLE
Add missing PDF setting to V2 Smoke test pipeline template (PHNX-5709)

### DIFF
--- a/v2/templates/PhoenixSmokeTestPipelineTemplate.json
+++ b/v2/templates/PhoenixSmokeTestPipelineTemplate.json
@@ -170,6 +170,15 @@
 			  }
 			 },
 			 "name": "LaunchDarklyOptions__SdkKey"
+			},
+			{
+				"envSource": {
+				  "configMapSource": {
+					"configMapName": "pdf-api",
+					"key": "url"
+				  }
+				},
+				"name": "HtmlToPdf__Host"
 			}
 		   ],
 		   "imageDescription": {


### PR DESCRIPTION
Motivation
----
* A new setting is required for a v2 templated service and that value was not set on the smoke test pipeline template for use causing testing issues

Modifications
----
* Added new setting to v2 spinnaker smoke test pipeline template

Result
----
QA tests should no longer fail due to a missing setting

https://centeredge.atlassian.net/browse/PHNX-5709
