### PR TITLE
Increase memory limits for business entities (PHNX-6016)

### DIFF
--- a/configs/businessentities/businessentities-config.yml
+++ b/configs/businessentities/businessentities-config.yml
@@ -4,7 +4,7 @@ pipeline:
   name: BusinessEntities Production
   id: phnx-businessentities-prod
   template:
-    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/PHNX-6016/templates/production-template.yml
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/production-template.yml
   variables:
     application: businessentities
     loadbalancer: businessentities-prod

--- a/configs/businessentities/businessentities-config.yml
+++ b/configs/businessentities/businessentities-config.yml
@@ -4,7 +4,7 @@ pipeline:
   name: BusinessEntities Production
   id: phnx-businessentities-prod
   template:
-    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/master/templates/production-template.yml
+    source: https://raw.githubusercontent.com/CenterEdge/Phoenix.Spinnaker.PipelineTemplates/PHNX-6016/templates/production-template.yml
   variables:
     application: businessentities
     loadbalancer: businessentities-prod
@@ -17,6 +17,8 @@ pipeline:
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-businessentities
     podAnnotations: "{ iam.amazonaws.com/role: PhoenixBusEntSvc, environment: prod }"
     podAnnotationsStaging: "{ iam.amazonaws.com/role: PhoenixBusEntSvc, environment: staging }"
+    requestmem: 1Gi
+    maxmem: 2Gi
   metadata:
     description: The Business Entities Production Pipeline Config
     name: BusinessEntities-Production

--- a/configs/businessentities/emergency-config.yml
+++ b/configs/businessentities/emergency-config.yml
@@ -12,6 +12,8 @@ pipeline:
     gcrrepo: phoenix-177420/phoenix-service-businessentities
     gcrimage: us.gcr.io/phoenix-177420/phoenix-service-businessentities
     podAnnotations: "{ iam.amazonaws.com/role: PhoenixBusEntSvc, environment: prod }"
+    requestmem: 1Gi
+    maxmem: 2Gi
   metadata:
     description: The Emergency Business Entities Production Pipeline Config
     name: Emergency-BusinessEntities-Production

--- a/templates/emergency-production-template.yml
+++ b/templates/emergency-production-template.yml
@@ -124,7 +124,7 @@ stages:
               secretName: couchbase-primary
           name: Couchbase__Password
         - name: ASPNETCORE_URLS
-          value: http://localhost:8080/
+          value: http://*:80/
         - envSource:
             configMapSource:
               configMapName: rabbitmq
@@ -188,7 +188,7 @@ stages:
           timeoutSeconds: 5
         name: "phoenix-{{ application }}-image"
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http
           protocol: TCP
         readinessProbe:
@@ -207,56 +207,6 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
-        requests:
-          cpu: "{{ requestcpu }}"
-          memory: "{{ requestmem }}"
-        volumeMounts: []
-      - args: []
-        command: []
-        envVars:
-        - name: STATSD_SERVER
-          envSource:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: STATSD_SAMPLE_RATE
-          value: "{{ statsdSampleRate }}"
-        - name: SERVICE_NAME
-          value: "prod.{{ application }}"
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__ConnectTimeout
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__ReadTimeout
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__SendTimeout
-        - envSource:
-            configMapSource:
-              configMapName: waiver-upload-options
-              key: max_size
-          name: WaiverUploadOptions__MaxRequestSize
-        imageDescription:
-          account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
-          registry: us.gcr.io
-          repository: phoenix-177420/nginx-proxy
-          tag: "27"
-        imagePullPolicy: IFNOTPRESENT
-        limits:
-          cpu: "{{ maxcpu }}"
-          memory: "{{ maxmem }}"
-        name: phoenix-177420-nginx-proxy
-        ports:
-        - containerPort: 80
-          name: http
-          protocol: TCP
         requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -404,7 +404,7 @@ stages:
               secretName: couchbase-primary
           name: Couchbase__Password
         - name: ASPNETCORE_URLS
-          value: http://localhost:8080/
+          value: http://localhost:80/
         - envSource:
             configMapSource:
               configMapName: rabbitmq
@@ -473,7 +473,7 @@ stages:
           timeoutSeconds: 5
         name: "phoenix-{{ application }}-image"
         ports:
-        - containerPort: 8080
+        - containerPort: 80
           name: http
           protocol: TCP
         readinessProbe:
@@ -492,56 +492,6 @@ stages:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
-        requests:
-          cpu: "{{ requestcpu }}"
-          memory: "{{ requestmem }}"
-        volumeMounts: []
-      - args: []
-        command: []
-        envVars:
-        - name: STATSD_SERVER
-          envSource:
-            fieldRef:
-              fieldPath: status.hostIP
-        - name: STATSD_SAMPLE_RATE
-          value: "{{ statsdSampleRate }}"
-        - name: SERVICE_NAME
-          value: "prod.{{ application }}"
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__ConnectTimeout
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__ReadTimeout
-        - envSource:
-            configMapSource:
-              configMapName: timeouts
-              key: connect_read_write
-          name: TimeoutOptions__SendTimeout
-        - envSource:
-            configMapSource:
-              configMapName: waiver-upload-options
-              key: max_size
-          name: WaiverUploadOptions__MaxRequestSize
-        imageDescription:
-          account: gcr-phoenix
-          imageId: us.gcr.io/phoenix-177420/nginx-proxy:27
-          registry: us.gcr.io
-          repository: phoenix-177420/nginx-proxy
-          tag: "27"
-        imagePullPolicy: IFNOTPRESENT
-        limits:
-          cpu: "{{ maxcpu }}"
-          memory: "{{ maxmem }}"
-        name: phoenix-177420-nginx-proxy
-        ports:
-        - containerPort: 80
-          name: http
-          protocol: TCP
         requests:
           cpu: "{{ requestcpu }}"
           memory: "{{ requestmem }}"

--- a/templates/production-template.yml
+++ b/templates/production-template.yml
@@ -404,7 +404,7 @@ stages:
               secretName: couchbase-primary
           name: Couchbase__Password
         - name: ASPNETCORE_URLS
-          value: http://localhost:80/
+          value: http://*:80/
         - envSource:
             configMapSource:
               configMapName: rabbitmq


### PR DESCRIPTION
Motivation
------------
We had an outage of the business entities microservice due to out of memory conditions causing the pods to be killed by k8s.  We increased the memory limits in production to get things back up and running and we need to put those changes in source control now.  We also want to remove the nginx proxy container from production as it is no longer needed.

Modifications
---------------
- Increased memory limits in business entities config
- Removed nginx proxy container from producution pipelines

https://centeredge.atlassian.net/browse/PHNX-6016
