### PR TITLE
Get advantageproxy config from ConfigMap (STAGE-4892)

### DIFF
--- a/templates/advantageproxy-template.json
+++ b/templates/advantageproxy-template.json
@@ -13,10 +13,10 @@
       "description": "Load Balancer Name"
     },
     {
-      "name": "relayDomainSuffix",
+      "name": "configMap",
       "type": "string",
-      "defaultValue": ".relay.int.centeredgeonline.com",
-      "description": "Relay Domain Suffix"
+      "defaultValue": "advantage-proxy",
+      "description": "Config Map"
     },
     {
       "name": "slackChannel",
@@ -153,7 +153,31 @@
           "envVars": [
            {
             "name": "RELAY_DOMAIN_SUFFIX",
-            "value": "${ templateVariables.relayDomainSuffix }"
+            "envSource": {
+              "configMapSource": {
+                "configMapName": "${ templateVariables.configMap }",
+                "key": "relayDomainSuffix",
+                "optional": false
+              }
+            }
+           },
+           {
+            "name": "QA_RELAY_DOMAIN_SUFFIX",
+            "envSource": {
+              "configMapSource": {
+                "configMapName": "${ templateVariables.configMap }",
+                "key": "qaRelayDomainSuffix"
+              }
+            }
+           },
+           {
+            "name": "QA_REGEX",
+            "envSource": {
+              "configMapSource": {
+                "configMapName": "${ templateVariables.configMap }",
+                "key": "qaRegex"
+              }
+            }
            },
            {
             "envSource": {


### PR DESCRIPTION
Motivation
----------
Add rules for forwarding traffic to QA sites via QA relay.

Modifications
-------------
Use a ConfigMap for advantageproxy environment variables, and add the
vars required for QA relay forwarding.

https://centeredge.atlassian.net/browse/STAGE-4892
