### PR TITLE
Fix Typo In Emergency KV2 Template (PHNX-6330)

### DIFF
--- a/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
@@ -1123,7 +1123,7 @@
                 "skipExpressionEvaluation": false,
                 "source": "text",
                 "stageEnabled": {
-                    "expression": "${ templateVariables.jobsEnabled ? \"#stage('Smoke Tests')['context']['buildInfo']['result']=='SUCCESS'\" : false }",
+                    "expression": "${ templateVariables.jobsEnabled }",
                     "type": "expression"
                 },
                 "stageTimeoutMs": 1200000,


### PR DESCRIPTION
Motivation
----
The stage for deploying job pods is currently checking if smoke tests have succeeded but the emergency pipeline does not care about smoke tests

Modifications
----
Set the stage to deploy baed solely whether job pods are enabled

Result
----
Job pods should now deploy without a care for smoke tests

https://centeredge.atlassian.net/browse/PHNX-6330
