### PR TITLE
Adjust Job Settings For KV2 Templates (PHNX-6332)

### DIFF
--- a/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
@@ -881,7 +881,7 @@
                                                 },
                                                 {
                                                     "name": "JobOptions__ProcessBulkJobs",
-                                                    "value": "false"
+                                                    "value": "true"
                                                 },
                                                 {
                                                     "name": "COGNITO__ClientId",

--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -691,7 +691,7 @@
                         },
                         {
                           "name": "JobOptions__ProcessBulkJobs",
-                          "value": "false"
+                          "value": "true"
                         },
                         {
                           "name": "COGNITO__ClientId",
@@ -1218,7 +1218,7 @@
                         },
                         {
                           "name": "JobOptions__ProcessBulkJobs",
-                          "value": "false"
+                          "value": "true"
                         },
                         {
                           "name": "COGNITO__ClientId",

--- a/kubernetesV2/PhoenixStagingPipelineTemplate.json
+++ b/kubernetesV2/PhoenixStagingPipelineTemplate.json
@@ -355,7 +355,7 @@
                                                 },
                                                 {
                                                     "name": "JobOptions__ProcessBulkJobs",
-                                                    "value": "false"
+                                                    "value": "true"
                                                 },
                                                 {
                                                     "name": "COGNITO__ClientId",


### PR DESCRIPTION
Motivation
----
All of the stages are currently setting the process jobs setting to false and we should be turning on the process job settings for jobs and staging clusters (for tests)

Modifications
----
* Adjusted Production/Emergency/Staging templates so that process bulk job is:
  * `ON` for staging clusters
  * `ON` for jobs clusters

Result
----
Process bulk job setting should now be on only for staging and jobs clusters and off for prod clusters

https://centeredge.atlassian.net/browse/PHNX-6332
