### PR TITLE
Fix Automated Trigger & IAM For Manual Staging KV2 Template(PHNX-6333)

### DIFF
--- a/kubernetesV2/PhoenixStagingPipelineTemplate.json
+++ b/kubernetesV2/PhoenixStagingPipelineTemplate.json
@@ -167,7 +167,8 @@
                                     "annotations": {
                                         "moniker.spinnaker.io/detail": "api",
                                         "moniker.spinnaker.io/stack": "staging",
-                                        "shawarma.centeredge.io/service-name": "${ templateVariables.stagingLoadBalancerName == '*' ? templateVariables.appName + '-staging-api' : templateVariables.stagingLoadBalancerName }"
+                                        "shawarma.centeredge.io/service-name": "${ templateVariables.stagingLoadBalancerName == '*' ? templateVariables.appName + '-staging-api' : templateVariables.stagingLoadBalancerName }",
+                                        "iam.amazonaws.com/role": "${ templateVariables.iamRole == '-' ? '' : templateVariables.iamRole }"
                                     },
                                     "labels": {
                                         "app": "${ templateVariables.appName }staging"
@@ -601,7 +602,7 @@
         "triggers": [
             {
                 "account": "gcr-phoenix",
-                "enabled": true,
+                "enabled": false,
                 "expectedArtifactIds": [
                     "0f5786e8-3a1e-4dc3-a038-3d31bf6c1366"
                 ],


### PR DESCRIPTION
Motivation
----
The manual staging is set to be auto triggered when it should be a manual one and it is missing the iam role

Modifications
----
* Turn off the automated trigger so only a human click can turn it on
* Apply IAM Role For Staging

Result
----
Manual Staging should not auto deploy on new builds

https://centeredge.atlassian.net/browse/PHNX-6333
