### PR TITLE
Add Auth Variables For Production Template (PHNX-6340)

### DIFF
--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -264,6 +264,56 @@
                         {
                           "name": "JobOptions__ProcessBulkJobs",
                           "value": "false"
+                        },
+                        {
+                          "name": "COGNITO__ClientId",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "key": "clientId",
+                              "name": "cognito-creds",
+                              "optional": true
+                            }
+                          }
+                        },
+                        {
+                          "name": "COGNITO__ClientSecret",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "key": "clientSecret",
+                              "name": "cognito-creds",
+                              "optional": true
+                            }
+                          }
+                        },
+                        {
+                          "name": "COGNITO__UserPoolId",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "key": "poolId",
+                              "name": "cognito-creds",
+                              "optional": true
+                            }
+                          }
+                        },
+                        {
+                          "name": "COGNITO__Region",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "key": "region",
+                              "name": "cognito-creds",
+                              "optional": true
+                            }
+                          }
+                        },
+                        {
+                          "name": "JwtOptions__Secret",
+                          "valueFrom": {
+                            "secretKeyRef": {
+                              "key": "secret",
+                              "name": "jwt-options",
+                              "optional": true
+                            }
+                          }
                         }
                       ],
                       "image": "us.gcr.io/${ templateVariables.gcrAccountName }/${ templateVariables.gcrImageName == '*' ? 'phoenix-service-' + templateVariables.appName : templateVariables.gcrImageName }",


### PR DESCRIPTION
Motivation
----
The main production template is missing the auth variables for the prod stage and it isn't getting the proper settings

Modifications
----
* Add the auth variables to the prod stage of the production template

Result
----
Auth variables should be applied to service pods for prod stage

https://centeredge.atlassian.net/browse/PHNX-6340
