### PR TITLE
Adjust Kv2 Production Template To Work With Nested Jobs (PHNX-6628)

### DIFF
--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -986,7 +986,7 @@
       {
         "continuePipeline": false,
         "failPipeline": true,
-        "job": "${ templateVariables.smokeTestJobFullName != '' ? templateVariables.smokeTestJobFullName : ('Phoenix/job/' + templateVariables.smokeTestJobDirectory + '/job/' + (templateVariables.nestedJobDirectory ? (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1) + '/job/' : templateVariables.smokeTestServiceName) + '/job/' : '') + (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1) : templateVariables.smokeTestServiceName) + '.' + templateVariables.smokeTestProjectSuffix) }",
+        "job": "${ templateVariables.smokeTestJobFullName != '-' ? templateVariables.smokeTestJobFullName : ('Phoenix/job/' + templateVariables.smokeTestJobDirectory + '/job/' + (templateVariables.nestedJobDirectory ? (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1)  + '/job/' : templateVariables.smokeTestServiceName) : '') + (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1) : templateVariables.smokeTestServiceName) + '.' + templateVariables.smokeTestProjectSuffix) }",
         "master": "primary-jenkins",
         "name": "Smoke Tests",
         "parameters": "${ templateVariables.smokeTestParameters }",
@@ -1574,8 +1574,8 @@
       "type": "string"
     },
     {
-      "defaultValue": "",
-      "description": "Full name of the smoke test job. If blank, it is built automatically from the other parameters.",
+      "defaultValue": "-",
+      "description": "Full name of the smoke test job. If '-', it is built automatically from the other parameters.",
       "name": "smokeTestJobFullName",
       "type": "string"
     },


### PR DESCRIPTION
Motivation
----
Some recent template changes broke spinnaker pipelines for production due to breaking nested job directories

Modifications
----
* Adjusted the logic for nested job directories to account for the recent changes
* Adjusted logic for smokeTestFullJobName to check a `-` character for using the default parse mechanism since a default empty string will cause Spinnaker UI to yell at a user if it is empty

Result
----
Production pipelines based off the production kv2 template should now work with nested job directories

https://centeredge.atlassian.net/browse/PHNX-6628
