### PR TITLE
Append Job Directory Field Name For Smoke Test Conditional(PHNX-6640)

### DIFF
--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -986,7 +986,7 @@
       {
         "continuePipeline": false,
         "failPipeline": true,
-        "job": "${ templateVariables.smokeTestJobFullName != '-' ? templateVariables.smokeTestJobFullName : ('Phoenix/job/' + templateVariables.smokeTestJobDirectory + '/job/' + (templateVariables.nestedJobDirectory ? (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1)  + '/job/' : templateVariables.smokeTestServiceName) : '') + (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1) : templateVariables.smokeTestServiceName) + '.' + templateVariables.smokeTestProjectSuffix) }",
+        "job": "${ templateVariables.smokeTestJobFullName != '-' ? templateVariables.smokeTestJobFullName : ('Phoenix/job/' + templateVariables.smokeTestJobDirectory + '/job/' + (templateVariables.nestedJobDirectory ? (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1)  + '/job/' : templateVariables.smokeTestServiceName  + '/job/' ) : '') + (templateVariables.smokeTestServiceName == '*' ? 'Phoenix.Service.' + templateVariables.appName.substring(0,1).toUpperCase() + templateVariables.appName.substring(1) : templateVariables.smokeTestServiceName) + '.' + templateVariables.smokeTestProjectSuffix) }",
         "master": "primary-jenkins",
         "name": "Smoke Tests",
         "parameters": "${ templateVariables.smokeTestParameters }",


### PR DESCRIPTION
Motivation
----
An earlier change removed the addition of the job directory name for a conditional branch, but it is needed and should have remained

Modifications
----
* Append the job directory field name for the logic branch

Result
----
The template should work again for the specific logic branch triggered

https://centeredge.atlassian.net/browse/PHNX-6640
