### PR TITLE
Update Staging/Production Templates To Nginx32 (PHNX-7208)

### DIFF
--- a/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
@@ -537,7 +537,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [
@@ -1065,7 +1065,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [

--- a/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
@@ -283,7 +283,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:31
+              image: us.gcr.io/phoenix-177420/nginx-proxy:32
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -642,7 +642,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:31
+              image: us.gcr.io/phoenix-177420/nginx-proxy:32
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:

--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -444,7 +444,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [
@@ -932,7 +932,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [
@@ -1458,7 +1458,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [

--- a/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
@@ -283,7 +283,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:31
+              image: us.gcr.io/phoenix-177420/nginx-proxy:32
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -617,7 +617,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:31
+              image: us.gcr.io/phoenix-177420/nginx-proxy:32
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -957,7 +957,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:31
+              image: us.gcr.io/phoenix-177420/nginx-proxy:32
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:

--- a/kubernetesV2/PhoenixStagingPipelineTemplate.json
+++ b/kubernetesV2/PhoenixStagingPipelineTemplate.json
@@ -502,7 +502,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:31",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [


### PR DESCRIPTION
Motivation
----
We are needing to update nginx to allow  for higher upload sizes on membership import endpoints

Modifications
----
* Use Nginx32 with the fix for import endpoints in MashTub

Result
----
Phoenix services should now be using nginx32 which has the changes for higher upload sizes for MashTub membership import endpoints

https://centeredge.atlassian.net/browse/PHNX-7208
