### PR TITLE
Reduce default nginx proxy timeout (PHNX-7329)

### DIFF
--- a/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
@@ -537,7 +537,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [
@@ -1065,7 +1065,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [

--- a/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
@@ -283,7 +283,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:32
+              image: us.gcr.io/phoenix-177420/nginx-proxy:33
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -642,7 +642,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:32
+              image: us.gcr.io/phoenix-177420/nginx-proxy:33
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:

--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -323,7 +323,7 @@
                               "fieldPath": "metadata.name"
                             }
                           }
-                        }                       
+                        }
                       ],
                       "image": "us.gcr.io/${ templateVariables.gcrAccountName }/${ templateVariables.gcrImageName == '*' ? 'phoenix-service-' + templateVariables.appName : templateVariables.gcrImageName }",
                       "imagePullPolicy": "IfNotPresent",
@@ -444,7 +444,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [
@@ -932,7 +932,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [
@@ -1337,7 +1337,7 @@
                               "fieldPath": "metadata.name"
                             }
                           }
-                        }                       
+                        }
                       ],
                       "image": "us.gcr.io/${ templateVariables.gcrAccountName }/${ templateVariables.gcrImageName == '*' ? 'phoenix-service-' + templateVariables.appName : templateVariables.gcrImageName }",
                       "imagePullPolicy": "IfNotPresent",
@@ -1458,7 +1458,7 @@
                           "value": "/health"
                         }
                       ],
-                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                      "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                       "imagePullPolicy": "IfNotPresent",
                       "name": "nginx-proxy",
                       "ports": [

--- a/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
@@ -283,7 +283,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:32
+              image: us.gcr.io/phoenix-177420/nginx-proxy:33
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -617,7 +617,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:32
+              image: us.gcr.io/phoenix-177420/nginx-proxy:33
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:
@@ -957,7 +957,7 @@ pipeline:
                 value: "8080"
               - name: HEALTH_CHECK_URI
                 value: /health
-              image: us.gcr.io/phoenix-177420/nginx-proxy:32
+              image: us.gcr.io/phoenix-177420/nginx-proxy:33
               imagePullPolicy: IfNotPresent
               name: nginx-proxy
               ports:

--- a/kubernetesV2/PhoenixStagingPipelineTemplate.json
+++ b/kubernetesV2/PhoenixStagingPipelineTemplate.json
@@ -502,7 +502,7 @@
                                                     "value": "/health"
                                                 }
                                             ],
-                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:32",
+                                            "image": "us.gcr.io/phoenix-177420/nginx-proxy:33",
                                             "imagePullPolicy": "IfNotPresent",
                                             "name": "nginx-proxy",
                                             "ports": [


### PR DESCRIPTION
Motivation
----------
The default timeout of 60s is too low and causing issues with credit
card processing.

Modifications
-------------
Switch to nginx proxy build 33 for our microservices and MashTub.