### PR TITLE
Make emergency pipelines v4 work (PHNX-7547)

### DIFF
--- a/kubernetesV2/v4/emergency-with-jobs.yaml
+++ b/kubernetesV2/v4/emergency-with-jobs.yaml
@@ -105,9 +105,6 @@ pipeline:
     - "6"
     skipExpressionEvaluation: false
     source: artifact
-    stageEnabled:
-      expression: "#stage('Smoke Tests')['context']['buildInfo']['result']=='SUCCESS'"
-      type: expression
     trafficManagement:
       enabled: false
       options:

--- a/kubernetesV2/v4/emergency.yaml
+++ b/kubernetesV2/v4/emergency.yaml
@@ -81,9 +81,6 @@ pipeline:
     - "6"
     skipExpressionEvaluation: false
     source: artifact
-    stageEnabled:
-      expression: "#stage('Smoke Tests')['context']['buildInfo']['result']=='SUCCESS'"
-      type: expression
     trafficManagement:
       enabled: false
       options:


### PR DESCRIPTION
Motivation
----------
The emergency pipeline deploys are incorrectly requiring smoke test
stages, causing the pipeline to not function.

Modifications
-------------
Remove the offending copy/pasta.

https://centeredge.atlassian.net/browse/PHNX-7547
