### PR TITLE
Add slack notifications to templates (PHNX-10115)

### DIFF
--- a/kubernetesV2/v4/emergency-with-jobs.yaml
+++ b/kubernetesV2/v4/emergency-with-jobs.yaml
@@ -28,6 +28,14 @@ pipeline:
       name: github-repo
       reference: ${templateVariables.gitHubRepo }
       type: git/repo
+  notifications:
+  - address: phoenixdev
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.starting
+    - pipeline.complete
+    - pipeline.failed
   keepWaitingPipelines: false
   limitConcurrent: true
   stages:

--- a/kubernetesV2/v4/emergency.yaml
+++ b/kubernetesV2/v4/emergency.yaml
@@ -28,6 +28,14 @@ pipeline:
       name: github-repo
       reference: ${templateVariables.gitHubRepo }
       type: git/repo
+  notifications:
+  - address: phoenixdev
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.starting
+    - pipeline.complete
+    - pipeline.failed
   keepWaitingPipelines: false
   limitConcurrent: true
   stages:

--- a/kubernetesV2/v4/production-with-jobs.yaml
+++ b/kubernetesV2/v4/production-with-jobs.yaml
@@ -28,6 +28,19 @@ pipeline:
       name: github-repo
       reference: ${templateVariables.gitHubRepo }
       type: git/repo
+  notifications:
+  - address: phoenixdev-ci
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.starting
+    - pipeline.complete
+    - pipeline.failed
+  - address: phoenixdev
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.failed
   keepWaitingPipelines: false
   limitConcurrent: true
   stages:

--- a/kubernetesV2/v4/production.yaml
+++ b/kubernetesV2/v4/production.yaml
@@ -28,6 +28,19 @@ pipeline:
       name: github-repo
       reference: ${templateVariables.gitHubRepo }
       type: git/repo
+  notifications:
+  - address: phoenixdev-ci
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.starting
+    - pipeline.complete
+    - pipeline.failed
+  - address: phoenixdev
+    level: pipeline
+    type: slack
+    when:
+    - pipeline.failed
   keepWaitingPipelines: false
   limitConcurrent: true
   stages:

--- a/kubernetesV2/v4/ui.json
+++ b/kubernetesV2/v4/ui.json
@@ -45,6 +45,26 @@
         ],
         "keepWaitingPipelines": false,
         "limitConcurrent": true,
+        "notifications": [
+          {
+            "address": "phoenixdev-ci",
+            "level": "pipeline",
+            "type": "slack",
+            "when": [
+              "pipeline.starting",
+              "pipeline.complete",
+              "pipeline.failed"
+            ]
+          },
+          {
+            "address": "phoenixdev",
+            "level": "pipeline",
+            "type": "slack",
+            "when": [
+              "pipeline.failed"
+            ]
+          }
+        ],
         "stages": [
             {
                 "expectedArtifacts": [


### PR DESCRIPTION
# Motivations
We want to be notified about deploy failures in the Phoenix environment

# Modifications
- Add slack notifications for all production pipelines in the slack channel #phoenixdev-cli
- Add slack notifications for all production pipeline failures, and ALL emergency pipelines in the slack channel #phoenixdev

https://centeredge.atlassian.net/browse/PHNX-10115
