### PR TITLE
Update the HorizontalPodAutoscaler api version (DO-2118)

### DIFF
--- a/kubernetesV2/PhoenixAdvantageProxyPipelineTemplate.yaml
+++ b/kubernetesV2/PhoenixAdvantageProxyPipelineTemplate.yaml
@@ -202,7 +202,7 @@ pipeline:
       spec:
         query: >-
           sum:phnx.request.count{app:${ templateVariables.appName },env:${ templateVariables.stackName == "prod" ? "production" : templateVariables.stackName }}.as_rate()
-    - apiVersion: autoscaling/v2beta2
+    - apiVersion: autoscaling/v2
       kind: HorizontalPodAutoscaler
       metadata:
         name: ${ templateVariables.appName }-prod-autoscaler

--- a/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplate.json
@@ -576,7 +576,7 @@
                         }
                     },
                     {
-                        "apiVersion": "autoscaling/v1",
+                        "apiVersion": "autoscaling/v2",
                         "kind": "HorizontalPodAutoscaler",
                         "metadata": {
                             "name": "${ templateVariables.appName }-prod-autoscaler",
@@ -1104,7 +1104,7 @@
                         }
                     },
                     {
-                        "apiVersion": "autoscaling/v1",
+                        "apiVersion": "autoscaling/v2",
                         "kind": "HorizontalPodAutoscaler",
                         "metadata": {
                             "name": "${ templateVariables.appName }-jobs-autoscaler",

--- a/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixEmergencyPipelineTemplateV3.yaml
@@ -315,7 +315,7 @@ pipeline:
         # Total HTTP requests received filtered to this deployments tags as a rate per second
         query: >-
           sum:phnx.request.count{app:${ templateVariables.appName },env:production,detail:api}.as_rate()
-    - apiVersion: autoscaling/v2beta2
+    - apiVersion: autoscaling/v2
       kind: HorizontalPodAutoscaler
       metadata:
         name: ${ templateVariables.appName }-prod-autoscaler
@@ -674,7 +674,7 @@ pipeline:
         # Total RabbitMQ events received filtered to this deployments tags as a rate per second
         query: >-
           sum:phnx.event.received.count{app:${ templateVariables.appName },env:production,detail:jobs}.as_rate()
-    - apiVersion: autoscaling/v2beta2
+    - apiVersion: autoscaling/v2
       kind: HorizontalPodAutoscaler
       metadata:
         name: ${ templateVariables.appName }-jobs-autoscaler

--- a/kubernetesV2/PhoenixProductionPipelineTemplate.json
+++ b/kubernetesV2/PhoenixProductionPipelineTemplate.json
@@ -483,7 +483,7 @@
             }
           },
           {
-            "apiVersion": "autoscaling/v1",
+            "apiVersion": "autoscaling/v2",
             "kind": "HorizontalPodAutoscaler",
             "metadata": {
               "name": "${ templateVariables.appName }-prod-autoscaler",
@@ -1497,7 +1497,7 @@
             }
           },
           {
-            "apiVersion": "autoscaling/v1",
+            "apiVersion": "autoscaling/v2",
             "kind": "HorizontalPodAutoscaler",
             "metadata": {
               "name": "${ templateVariables.appName }-jobs-autoscaler",

--- a/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
+++ b/kubernetesV2/PhoenixProductionPipelineTemplateV3.yaml
@@ -315,7 +315,7 @@ pipeline:
         # Total HTTP requests received filtered to this deployments tags as a rate per second
         query: >-
           sum:phnx.request.count{app:${ templateVariables.appName },env:production,detail:api}.as_rate()
-    - apiVersion: autoscaling/v2beta2
+    - apiVersion: autoscaling/v2
       kind: HorizontalPodAutoscaler
       metadata:
         name: ${ templateVariables.appName }-prod-autoscaler
@@ -989,7 +989,7 @@ pipeline:
         # Total RabbitMQ events received filtered to this deployments tags as a rate per second
         query: >-
           sum:phnx.event.received.count{app:${ templateVariables.appName },env:production,detail:jobs}.as_rate()
-    - apiVersion: autoscaling/v2beta2
+    - apiVersion: autoscaling/v2
       kind: HorizontalPodAutoscaler
       metadata:
         name: ${ templateVariables.appName }-jobs-autoscaler

--- a/kubernetesV2/PhoenixUIPipelineTemplate.json
+++ b/kubernetesV2/PhoenixUIPipelineTemplate.json
@@ -213,7 +213,7 @@
                         }
                     },
                     {
-                        "apiVersion": "autoscaling/v1",
+                        "apiVersion": "autoscaling/v2",
                         "kind": "HorizontalPodAutoscaler",
                         "metadata": {
                             "name": "${ templateVariables.appName }-prod-autoscaler",


### PR DESCRIPTION
Motivation
----------
K8s version 1.25 removes the v2beta1 version of HorizontalPodAutoscaler

Modifications
-------------
Update the version to v2

https://centeredge.atlassian.net/browse/DO-2018

https://centeredge.atlassian.net/browse/DO-2118
